### PR TITLE
Fix Jellyfin published server URL

### DIFF
--- a/apps/jellyfin/overlays/nishir/deployment.patch.yaml
+++ b/apps/jellyfin/overlays/nishir/deployment.patch.yaml
@@ -10,7 +10,7 @@ spec:
         - name: jellyfin
           env:
             - name: JELLYFIN_PublishedServerUrl
-              value: jellyfin.tail9fed3.ts.net
+              value: "100.83.158.44"
           volumeMounts:
             - name: data-sukebe
               mountPath: /data/sukebe/jav


### PR DESCRIPTION
Fix Jellyfin published server URL

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/shikanime/manifests/pull/47).
* __->__ #47
* #46
* #45