### PR TITLE
Fix missing service type on rclone-webdav

### DIFF
--- a/apps/rclone/base/svc.yaml
+++ b/apps/rclone/base/svc.yaml
@@ -11,6 +11,7 @@ spec:
       targetPort: webdav
   selector:
     app.kubernetes.io/name: rclone
+  type: LoadBalancer
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #153

