### PR TITLE
Fix Rclone config not found

### DIFF
--- a/apps/rclone/base/kustomization.yaml
+++ b/apps/rclone/base/kustomization.yaml
@@ -3,7 +3,7 @@ kind: Kustomization
 configMapGenerator:
   - literals:
       - rclone.conf=""
-    name: rclone-config
+    name: rclone
     namespace: shikanime
 images:
   - name: rclone


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #190
* #189
* __->__ #188

