### PR TITLE
Fix missing Transmission scripts namespace

### DIFF
--- a/apps/transmission/base/kustomization.yaml
+++ b/apps/transmission/base/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 configMapGenerator:
   - name: transmission-scripts
+    namespace: shikanime
     files:
       - scripts/cleanup.sh
 images:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

