### PR TITLE
Fix Jellyfin HTTPS port

### DIFF
--- a/apps/jellyfin/components/tls/svc.yaml
+++ b/apps/jellyfin/components/tls/svc.yaml
@@ -6,5 +6,5 @@ metadata:
 spec:
   ports:
     - name: https
-      port: 443
+      port: 8920
       targetPort: https


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #298

