### PR TITLE
Fix missing Multus DHCP plugin

### DIFF
--- a/infra/nishir-leader/templates/manifests/multus.yaml.tftpl
+++ b/infra/nishir-leader/templates/manifests/multus.yaml.tftpl
@@ -18,3 +18,5 @@ spec:
         confDir: /var/lib/rancher/k3s/agent/etc/cni/net.d
         binDir: /var/lib/rancher/k3s/data/cni/
         kubeconfig: /var/lib/rancher/k3s/agent/etc/cni/net.d/multus.d/multus.kubeconfig
+    manifests:
+      dhcpDaemonSet: true


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* #313
* __->__ #312

