### PR TITLE
Fix missing Whisparr image

### DIFF
--- a/apps/whisparr/base/kustomization.yaml
+++ b/apps/whisparr/base/kustomization.yaml
@@ -3,7 +3,7 @@ kind: Kustomization
 images:
   - name: whisparr
     newName: ghcr.io/hotio/whisparr
-    newTag: v3-3.0.1.1264
+    newTag: v3-3.0.1.1304
 resources:
   - ingress.yaml
   - pvc.yaml


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

