### PR TITLE
Fix Vaultwarden missing secret

### DIFF
--- a/apps/vaultwarden/overlays/tailnet/kustomization.yaml
+++ b/apps/vaultwarden/overlays/tailnet/kustomization.yaml
@@ -3,4 +3,4 @@ kind: Kustomization
 components:
   - ../../components/tailscale
 resources:
-  - ../default
+  - ../nishir


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

