### PR TITLE
Remove useless tls hosts from ingress

### DIFF
--- a/apps/bazarr/base/ingress.yaml
+++ b/apps/bazarr/base/ingress.yaml
@@ -8,6 +8,3 @@ spec:
       name: bazarr
       port:
         name: http
-  tls:
-    - hosts:
-        - bazarr

--- a/apps/copyparty/base/ingress.yaml
+++ b/apps/copyparty/base/ingress.yaml
@@ -8,6 +8,3 @@ spec:
       name: copyparty
       port:
         name: http
-  tls:
-    - hosts:
-        - copyparty

--- a/apps/forgejo/base/ingress.yaml
+++ b/apps/forgejo/base/ingress.yaml
@@ -8,6 +8,3 @@ spec:
       name: forgejo
       port:
         name: http
-  tls:
-    - hosts:
-        - forgejo

--- a/apps/gitea-mirror/base/ingress.yaml
+++ b/apps/gitea-mirror/base/ingress.yaml
@@ -8,6 +8,3 @@ spec:
       name: gitea-mirror
       port:
         name: http
-  tls:
-    - hosts:
-        - gitea-mirror

--- a/apps/jellyfin/base/ingress.yaml
+++ b/apps/jellyfin/base/ingress.yaml
@@ -8,6 +8,3 @@ spec:
       name: jellyfin
       port:
         name: http
-  tls:
-    - hosts:
-        - jellyfin

--- a/apps/lidarr/base/ingress.yaml
+++ b/apps/lidarr/base/ingress.yaml
@@ -8,6 +8,3 @@ spec:
       name: lidarr
       port:
         name: http
-  tls:
-    - hosts:
-        - lidarr

--- a/apps/matrix/base/ingress.yaml
+++ b/apps/matrix/base/ingress.yaml
@@ -49,14 +49,14 @@ metadata:
 spec:
   defaultBackend:
     service:
-      name: matrix-proxy
+      name: matrix
       port:
         name: http
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: matrix-proxy-discord-media
+  name: matrix-discord-media
 spec:
   defaultBackend:
     service:

--- a/apps/matrix/base/ingress.yaml
+++ b/apps/matrix/base/ingress.yaml
@@ -8,9 +8,6 @@ spec:
       name: matrix-discord
       port:
         name: http
-  tls:
-    - hosts:
-        - matrix-discord
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
@@ -22,9 +19,6 @@ spec:
       name: matrix-googlechat
       port:
         name: http
-  tls:
-    - hosts:
-        - matrix-googlechat
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
@@ -36,9 +30,6 @@ spec:
       name: matrix-linkedin
       port:
         name: http
-  tls:
-    - hosts:
-        - matrix-linkedin
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
@@ -50,23 +41,17 @@ spec:
       name: matrix-meta
       port:
         name: http
-  tls:
-    - hosts:
-        - matrix-meta
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: matrix-proxy
+  name: matrix
 spec:
   defaultBackend:
     service:
       name: matrix-proxy
       port:
         name: http
-  tls:
-    - hosts:
-        - matrix
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
@@ -78,9 +63,6 @@ spec:
       name: matrix-proxy
       port:
         name: http
-  tls:
-    - hosts:
-        - matrix-discord-media
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
@@ -92,9 +74,6 @@ spec:
       name: matrix-signal
       port:
         name: http
-  tls:
-    - hosts:
-        - matrix-signal
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
@@ -106,9 +85,6 @@ spec:
       name: matrix-slack
       port:
         name: http
-  tls:
-    - hosts:
-        - matrix-slack
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
@@ -120,9 +96,6 @@ spec:
       name: matrix-twitter
       port:
         name: http
-  tls:
-    - hosts:
-        - matrix-twitter
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
@@ -134,6 +107,3 @@ spec:
       name: matrix-whatsapp
       port:
         name: http
-  tls:
-    - hosts:
-        - matrix-whatsapp

--- a/apps/matrix/components/tls/patch-ingress.yaml
+++ b/apps/matrix/components/tls/patch-ingress.yaml
@@ -1,7 +1,7 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: matrix-proxy
+  name: matrix
 spec:
   defaultBackend:
     service:
@@ -12,7 +12,7 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: matrix-proxy-discord-media
+  name: matrix-discord-media
 spec:
   defaultBackend:
     service:

--- a/apps/matrix/overlays/nishir-tailnet/patch-ingress.yaml
+++ b/apps/matrix/overlays/nishir-tailnet/patch-ingress.yaml
@@ -42,7 +42,7 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: matrix-proxy-discord-media
+  name: matrix-discord-media
   annotations:
     tailscale.com/funnel: "true"
     tailscale.com/proxy-class: matrix-proxy

--- a/apps/prowlarr/base/ingress.yaml
+++ b/apps/prowlarr/base/ingress.yaml
@@ -8,6 +8,3 @@ spec:
       name: prowlarr
       port:
         name: http
-  tls:
-    - hosts:
-        - prowlarr

--- a/apps/qbittorrent/base/ingress.yaml
+++ b/apps/qbittorrent/base/ingress.yaml
@@ -8,6 +8,3 @@ spec:
       name: qbittorrent
       port:
         name: http
-  tls:
-    - hosts:
-        - qbittorrent

--- a/apps/radarr/base/ingress.yaml
+++ b/apps/radarr/base/ingress.yaml
@@ -8,6 +8,3 @@ spec:
       name: radarr
       port:
         name: http
-  tls:
-    - hosts:
-        - radarr

--- a/apps/seerr/base/ingress.yaml
+++ b/apps/seerr/base/ingress.yaml
@@ -8,6 +8,3 @@ spec:
       name: seerr
       port:
         name: http
-  tls:
-    - hosts:
-        - seerr

--- a/apps/sonarr/base/ingress.yaml
+++ b/apps/sonarr/base/ingress.yaml
@@ -8,6 +8,3 @@ spec:
       name: sonarr
       port:
         name: http
-  tls:
-    - hosts:
-        - sonarr

--- a/apps/syncthing/base/ingress.yaml
+++ b/apps/syncthing/base/ingress.yaml
@@ -8,6 +8,3 @@ spec:
       name: syncthing
       port:
         name: http
-  tls:
-    - hosts:
-        - syncthing

--- a/apps/vaultwarden/base/ingress.yaml
+++ b/apps/vaultwarden/base/ingress.yaml
@@ -8,6 +8,3 @@ spec:
       name: vaultwarden
       port:
         name: http
-  tls:
-    - hosts:
-        - vaultwarden

--- a/apps/whisparr/base/ingress.yaml
+++ b/apps/whisparr/base/ingress.yaml
@@ -8,6 +8,3 @@ spec:
       name: whisparr
       port:
         name: http
-  tls:
-    - hosts:
-        - whisparr


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* #997
* #996
* __->__ #995

Signed-off-by: William Phetsinorath <william.phetsinorath@shikanime.studio>
Change-Id: Id039c799d64e50ea5eba2c7c60ab931f6a6a6964