### PR TITLE
Reverse Jellyfin dependency on Metatube

### DIFF
--- a/clusters/nishir/overlays/tailnet/ks.yaml
+++ b/clusters/nishir/overlays/tailnet/ks.yaml
@@ -130,7 +130,6 @@ metadata:
   namespace: flux-system
 spec:
   dependsOn:
-    - name: apps-metatube
     - name: infrastructure-longhorn
     - name: infrastructure-tailscale
   interval: 10m
@@ -242,6 +241,7 @@ metadata:
   namespace: flux-system
 spec:
   dependsOn:
+    - name: apps-jellyfin
     - name: infrastructure-longhorn
   interval: 10m
   path: ./apps/metatube/overlays/nishir


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* __->__ #1071

Signed-off-by: William Phetsinorath <william.phetsinorath@shikanime.studio>
Change-Id: I56578b6d5ed17ee7215cbb136e266f8d6a6a6964