### PR TITLE
Fix Mautrix missing Rclone image

### DIFF
--- a/apps/bazarr/base/kustomization.yaml
+++ b/apps/bazarr/base/kustomization.yaml
@@ -9,12 +9,12 @@ configMapGenerator:
     name: bazarr-rclone
     namespace: shikanime
 images:
-  - name: rclone
-    newName: rclone/rclone
-    newTag: 1.71.2
   - name: bazarr
     newName: lscr.io/linuxserver/bazarr
     newTag: 1.5.3
+  - name: rclone
+    newName: rclone/rclone
+    newTag: 1.71.2
 labels:
   - pairs:
       app.kubernetes.io/component: library-manager

--- a/apps/mautrix/discord/base/kustomization.yaml
+++ b/apps/mautrix/discord/base/kustomization.yaml
@@ -18,3 +18,6 @@ images:
   - name: mautrix
     newName: dock.mau.dev/mautrix/discord
     newTag: v0.7.6
+  - name: rclone
+    newName: rclone/rclone
+    newTag: 1.71.2

--- a/apps/mautrix/googlechat/base/kustomization.yaml
+++ b/apps/mautrix/googlechat/base/kustomization.yaml
@@ -18,3 +18,6 @@ images:
   - name: mautrix
     newName: dock.mau.dev/mautrix/googlechat
     newTag: v0.5.2
+  - name: rclone
+    newName: rclone/rclone
+    newTag: 1.71.2

--- a/apps/mautrix/linkedin/base/kustomization.yaml
+++ b/apps/mautrix/linkedin/base/kustomization.yaml
@@ -18,3 +18,6 @@ images:
   - name: mautrix
     newName: dock.mau.dev/mautrix/linkedin
     newTag: v0.2602.0
+  - name: rclone
+    newName: rclone/rclone
+    newTag: 1.71.2

--- a/apps/mautrix/meta/base/kustomization.yaml
+++ b/apps/mautrix/meta/base/kustomization.yaml
@@ -18,3 +18,6 @@ images:
   - name: mautrix
     newName: dock.mau.dev/mautrix/meta
     newTag: v0.2602.0
+  - name: rclone
+    newName: rclone/rclone
+    newTag: 1.71.2

--- a/apps/mautrix/signal/base/kustomization.yaml
+++ b/apps/mautrix/signal/base/kustomization.yaml
@@ -18,3 +18,6 @@ images:
   - name: mautrix
     newName: dock.mau.dev/mautrix/signal
     newTag: v0.2603.0
+  - name: rclone
+    newName: rclone/rclone
+    newTag: 1.71.2

--- a/apps/mautrix/slack/base/kustomization.yaml
+++ b/apps/mautrix/slack/base/kustomization.yaml
@@ -18,3 +18,6 @@ images:
   - name: mautrix
     newName: dock.mau.dev/mautrix/slack
     newTag: v0.2603.0
+  - name: rclone
+    newName: rclone/rclone
+    newTag: 1.71.2

--- a/apps/mautrix/twitter/base/kustomization.yaml
+++ b/apps/mautrix/twitter/base/kustomization.yaml
@@ -18,3 +18,6 @@ images:
   - name: mautrix
     newName: dock.mau.dev/mautrix/twitter
     newTag: v0.2603.0
+  - name: rclone
+    newName: rclone/rclone
+    newTag: 1.71.2

--- a/apps/mautrix/whatsapp/base/kustomization.yaml
+++ b/apps/mautrix/whatsapp/base/kustomization.yaml
@@ -18,3 +18,6 @@ images:
   - name: mautrix
     newName: dock.mau.dev/mautrix/whatsapp
     newTag: v0.2603.0
+  - name: rclone
+    newName: rclone/rclone
+    newTag: 1.71.2


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* __->__ #1099

Signed-off-by: William Phetsinorath <william.phetsinorath@shikanime.studio>
Change-Id: Icd01b37ea98d00b31f1bd0cb2edb5d3c6a6a6964