### PR TITLE
Add Chrome missing VPA

### DIFF
--- a/apps/chrome/base/kustomization.yaml
+++ b/apps/chrome/base/kustomization.yaml
@@ -16,3 +16,4 @@ labels:
 resources:
   - deploy.yaml
   - svc.yaml
+  - vpa.yaml

--- a/apps/chrome/base/vpa.yaml
+++ b/apps/chrome/base/vpa.yaml
@@ -1,0 +1,11 @@
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: chrome
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: chrome
+  updatePolicy:
+    updateMode: Auto


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* #1121
* __->__ #1120

Signed-off-by: William Phetsinorath <william.phetsinorath@shikanime.studio>
Change-Id: I2e3c7b7414316358dbb48dc2cd4b60a26a6a6964