### PR TITLE
Fix Cluster API missing namespace

### DIFF
--- a/infrastructure/cluster-api/base/kustomization.yaml
+++ b/infrastructure/cluster-api/base/kustomization.yaml
@@ -3,4 +3,3 @@ kind: Kustomization
 resources:
   - helmrepo.yaml
   - hr.yaml
-  - ns.yaml


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* #1144
* __->__ #1148

Signed-off-by: William Phetsinorath <william.phetsinorath@shikanime.studio>
Change-Id: I51aff1b5558747c3238c0418270bd8f86a6a6964