### PR TITLE
Fix cert-manager missing base ref

### DIFF
--- a/configs/cert-manager/overlays/nishir/kustomization.yaml
+++ b/configs/cert-manager/overlays/nishir/kustomization.yaml
@@ -1,6 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ../base
   - bundle.yaml
   - cert.yaml
   - clusterissuer.yaml


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* __->__ #1156

Signed-off-by: William Phetsinorath <william.phetsinorath@shikanime.studio>
Change-Id: I96ecaa1bd277f2278638634c354996146a6a6964