### PR TITLE
Remove Synapse empty volumes

### DIFF
--- a/apps/synapse/overlays/nishir/patch-sts.yaml
+++ b/apps/synapse/overlays/nishir/patch-sts.yaml
@@ -33,4 +33,3 @@ spec:
             timeoutSeconds: 15
             periodSeconds: 10
             failureThreshold: 180
-      volumes:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* __->__ #1194

Signed-off-by: William Phetsinorath <william.phetsinorath@shikanime.studio>
Change-Id: Idac63873418d08066d9edc7ef79f64bb6a6a6964