### PR TITLE
Fix missing Gatekeeper library Git repo

### DIFF
--- a/infrastructure/gatekeeper/base/kustomization.yaml
+++ b/infrastructure/gatekeeper/base/kustomization.yaml
@@ -1,5 +1,6 @@
 ---
 resources:
+  - gitrepo.yaml
   - helmrepo.yaml
   - hr.yaml
 apiVersion: kustomize.config.k8s.io/v1beta1


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* __->__ #1199

Signed-off-by: William Phetsinorath <william.phetsinorath@shikanime.studio>
Change-Id: I7eb3e5a77caa9a4a73e6c3a0ff18a4e76a6a6964