### PR TITLE
Fix Gatekeeper config bad naming

### DIFF
--- a/infrastructure/gatekeeper/overlays/nishir/ks.yaml
+++ b/infrastructure/gatekeeper/overlays/nishir/ks.yaml
@@ -2,7 +2,7 @@
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: gatekeeper-library
+  name: gatekeeper-config
   namespace: flux-system
 spec:
   dependsOn:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* __->__ #1200

Signed-off-by: William Phetsinorath <william.phetsinorath@shikanime.studio>
Change-Id: I7f25b72440670f3e4b73543a585e60886a6a6964