### PR TITLE
Fix Jellyfin missing template labels

### DIFF
--- a/apps/jellyfin/overlays/nishir-tailnet/kustomization.yaml
+++ b/apps/jellyfin/overlays/nishir-tailnet/kustomization.yaml
@@ -7,7 +7,8 @@ patches:
   - path: patch-ingress.yaml
   - path: patch-sts.yaml
 labels:
-  - pairs:
+  - includeTemplates: true
+    pairs:
       app.kubernetes.io/component: media-server
       app.kubernetes.io/instance: jellyfin
       app.kubernetes.io/name: jellyfin


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* __->__ #1223

Signed-off-by: William Phetsinorath <william.phetsinorath@shikanime.studio>
Change-Id: Ic3d562948a3f2044798803e19195f4ea6a6a6964