### PR TITLE
Fix missing Jellyfin allowed repo

### DIFF
--- a/configs/gatekeeper/overlays/nishir/constraints.yaml
+++ b/configs/gatekeeper/overlays/nishir/constraints.yaml
@@ -23,6 +23,7 @@ spec:
       - ghcr.io/raylabshq/
       - ghcr.io/seer-team/
       - ghcr.io/shikanime/
+      - jellyfin/
       - lscr.io/linuxserver/
       - matrixdotorg/
       - nousresearch/


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* __->__ #1224

Signed-off-by: William Phetsinorath <william.phetsinorath@shikanime.studio>
Change-Id: I552e9a6be4be13b2b97e7e2ba9bc5dd46a6a6964