### PR TITLE
Revert "Emmergency disable Gatekeeper"

### DIFF
--- a/clusters/nishir/overlays/tailnet/ks.yaml
+++ b/clusters/nishir/overlays/tailnet/ks.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: flux-system
 spec:
   dependsOn:
+    - name: infrastructure-gatekeeper
     - name: infrastructure-tailscale
     - name: infrastructure-vpa
   interval: 10m
@@ -31,6 +32,7 @@ metadata:
   namespace: flux-system
 spec:
   dependsOn:
+    - name: infrastructure-gatekeeper
     - name: infrastructure-tailscale
     - name: infrastructure-vpa
   interval: 10m
@@ -56,6 +58,7 @@ metadata:
   namespace: flux-system
 spec:
   dependsOn:
+    - name: infrastructure-gatekeeper
     - name: infrastructure-tailscale
     - name: infrastructure-vpa
   interval: 10m
@@ -81,6 +84,7 @@ metadata:
   namespace: flux-system
 spec:
   dependsOn:
+    - name: infrastructure-gatekeeper
     - name: infrastructure-tailscale
     - name: infrastructure-vpa
   interval: 10m
@@ -106,6 +110,7 @@ metadata:
   namespace: flux-system
 spec:
   dependsOn:
+    - name: infrastructure-gatekeeper
     - name: infrastructure-tailscale
     - name: infrastructure-vpa
   interval: 10m
@@ -131,6 +136,7 @@ metadata:
   namespace: flux-system
 spec:
   dependsOn:
+    - name: infrastructure-gatekeeper
     - name: infrastructure-vpa
   interval: 10m
   path: ./apps/chrome/overlays/nishir-tailnet
@@ -151,6 +157,7 @@ metadata:
   namespace: flux-system
 spec:
   dependsOn:
+    - name: infrastructure-gatekeeper
     - name: infrastructure-vpa
   interval: 10m
   path: ./apps/hermes-agent-postgres/overlays/nishir-tailnet
@@ -175,6 +182,7 @@ metadata:
   namespace: flux-system
 spec:
   dependsOn:
+    - name: infrastructure-gatekeeper
     - name: infrastructure-tailscale
     - name: infrastructure-vpa
   interval: 10m
@@ -200,6 +208,7 @@ metadata:
   namespace: flux-system
 spec:
   dependsOn:
+    - name: infrastructure-gatekeeper
     - name: infrastructure-tailscale
     - name: infrastructure-vpa
   interval: 10m
@@ -225,6 +234,7 @@ metadata:
   namespace: flux-system
 spec:
   dependsOn:
+    - name: infrastructure-gatekeeper
     - name: infrastructure-tailscale
     - name: infrastructure-vpa
   interval: 10m
@@ -250,6 +260,7 @@ metadata:
   namespace: flux-system
 spec:
   dependsOn:
+    - name: infrastructure-gatekeeper
     - name: infrastructure-vpa
   interval: 10m
   path: ./apps/mautrix/discord/overlays/nishir-tailnet
@@ -274,6 +285,7 @@ metadata:
   namespace: flux-system
 spec:
   dependsOn:
+    - name: infrastructure-gatekeeper
     - name: infrastructure-vpa
   interval: 10m
   path: ./apps/mautrix/googlechat/overlays/nishir-tailnet
@@ -298,6 +310,7 @@ metadata:
   namespace: flux-system
 spec:
   dependsOn:
+    - name: infrastructure-gatekeeper
     - name: infrastructure-vpa
   interval: 10m
   path: ./apps/mautrix/linkedin/overlays/nishir-tailnet
@@ -322,6 +335,7 @@ metadata:
   namespace: flux-system
 spec:
   dependsOn:
+    - name: infrastructure-gatekeeper
     - name: infrastructure-vpa
   interval: 10m
   path: ./apps/mautrix/meta/overlays/nishir-tailnet
@@ -346,6 +360,7 @@ metadata:
   namespace: flux-system
 spec:
   dependsOn:
+    - name: infrastructure-gatekeeper
     - name: infrastructure-vpa
   interval: 10m
   path: ./apps/mautrix/signal/overlays/nishir-tailnet
@@ -370,6 +385,7 @@ metadata:
   namespace: flux-system
 spec:
   dependsOn:
+    - name: infrastructure-gatekeeper
     - name: infrastructure-vpa
   interval: 10m
   path: ./apps/mautrix/slack/overlays/nishir-tailnet
@@ -394,6 +410,7 @@ metadata:
   namespace: flux-system
 spec:
   dependsOn:
+    - name: infrastructure-gatekeeper
     - name: infrastructure-vpa
   interval: 10m
   path: ./apps/mautrix/twitter/overlays/nishir-tailnet
@@ -418,6 +435,7 @@ metadata:
   namespace: flux-system
 spec:
   dependsOn:
+    - name: infrastructure-gatekeeper
     - name: infrastructure-vpa
   interval: 10m
   path: ./apps/mautrix/whatsapp/overlays/nishir-tailnet
@@ -442,6 +460,7 @@ metadata:
   namespace: flux-system
 spec:
   dependsOn:
+    - name: infrastructure-gatekeeper
     - name: infrastructure-vpa
   interval: 10m
   path: ./apps/metatube/overlays/nishir-tailnet
@@ -466,6 +485,7 @@ metadata:
   namespace: flux-system
 spec:
   dependsOn:
+    - name: infrastructure-gatekeeper
     - name: infrastructure-tailscale
     - name: infrastructure-vpa
   interval: 10m
@@ -491,6 +511,7 @@ metadata:
   namespace: flux-system
 spec:
   dependsOn:
+    - name: infrastructure-gatekeeper
     - name: infrastructure-tailscale
     - name: infrastructure-vpa
   interval: 10m
@@ -516,6 +537,7 @@ metadata:
   namespace: flux-system
 spec:
   dependsOn:
+    - name: infrastructure-gatekeeper
     - name: infrastructure-tailscale
     - name: infrastructure-vpa
   interval: 10m
@@ -541,6 +563,7 @@ metadata:
   namespace: flux-system
 spec:
   dependsOn:
+    - name: infrastructure-gatekeeper
     - name: infrastructure-tailscale
     - name: infrastructure-vpa
   interval: 10m
@@ -566,6 +589,7 @@ metadata:
   namespace: flux-system
 spec:
   dependsOn:
+    - name: infrastructure-gatekeeper
     - name: infrastructure-tailscale
     - name: infrastructure-vpa
   interval: 10m
@@ -591,6 +615,7 @@ metadata:
   namespace: flux-system
 spec:
   dependsOn:
+    - name: infrastructure-gatekeeper
     - name: infrastructure-tailscale
     - name: infrastructure-vpa
   interval: 10m
@@ -616,6 +641,7 @@ metadata:
   namespace: flux-system
 spec:
   dependsOn:
+    - name: infrastructure-gatekeeper
     - name: infrastructure-tailscale
     - name: infrastructure-vpa
   interval: 10m
@@ -637,6 +663,7 @@ metadata:
   namespace: flux-system
 spec:
   dependsOn:
+    - name: infrastructure-gatekeeper
     - name: infrastructure-tailscale
     - name: infrastructure-vpa
   interval: 10m
@@ -662,6 +689,7 @@ metadata:
   namespace: flux-system
 spec:
   dependsOn:
+    - name: infrastructure-gatekeeper
     - name: infrastructure-tailscale
     - name: infrastructure-vpa
   interval: 10m
@@ -687,6 +715,7 @@ metadata:
   namespace: flux-system
 spec:
   dependsOn:
+    - name: infrastructure-gatekeeper
     - name: infrastructure-tailscale
     - name: infrastructure-vpa
   interval: 10m

--- a/clusters/nishir/overlays/tailnet/kustomization.yaml
+++ b/clusters/nishir/overlays/tailnet/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
 components:
   - ../../components/cert-manager
   - ../../components/descheduler
+  - ../../components/gatekeeper
   - ../../components/grafana
   - ../../components/longhorn
   - ../../components/nfd


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* __->__ #1229

This reverts commit aa6b71259fa275bdb6a888c74c172c6cb4e6dd1d.