### PR TITLE
Add missing Forgejo image repo

### DIFF
--- a/configs/gatekeeper/overlays/nishir/constraints.yaml
+++ b/configs/gatekeeper/overlays/nishir/constraints.yaml
@@ -16,6 +16,7 @@ spec:
   parameters:
     repos:
       - chromedp/
+      - codeberg.org/forgejo/
       - copyparty/
       - dock.mau.dev/mautrix/
       - ghcr.io/hotio/


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* __->__ #1244

Signed-off-by: William Phetsinorath <william.phetsinorath@shikanime.studio>
Change-Id: I7f818f5add3696b3c1a36fa5e85199e76a6a6964