### PR TITLE
Fix applyTo doesn't exists on mutation

### DIFF
--- a/configs/gatekeeper/base/mutations.yaml
+++ b/configs/gatekeeper/base/mutations.yaml
@@ -4,13 +4,6 @@ kind: AssignMetadata
 metadata:
   name: set-ingress-allow-http-false
 spec:
-  applyTo:
-    - groups:
-        - networking.k8s.io
-      kinds:
-        - Ingress
-      versions:
-        - v1
   location: 'metadata.annotations."kubernetes.io/ingress.allow-http"'
   match:
     kinds:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* #1284
* #1283
* __->__ #1282
* #1281

Signed-off-by: William Phetsinorath <william.phetsinorath@shikanime.studio>
Change-Id: I6047a65780862e41888156e062695c676a6a6964