### PR TITLE
Seer may have migration at startup

### DIFF
--- a/apps/seerr/base/sts.yaml
+++ b/apps/seerr/base/sts.yaml
@@ -42,7 +42,7 @@ spec:
               port: http
             initialDelaySeconds: 20
             timeoutSeconds: 5
-            failureThreshold: 180
+            failureThreshold: 360
           volumeMounts:
             - name: config
               mountPath: /app/config


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* __->__ #1285

Signed-off-by: William Phetsinorath <william.phetsinorath@shikanime.studio>
Change-Id: Ied835f0c0494573835bb59463f97929e6a6a6964