### PR TITLE
Fix Hermes agent secretname typo

### DIFF
--- a/apps/hermes-agent/gateway/base/sts.yaml
+++ b/apps/hermes-agent/gateway/base/sts.yaml
@@ -99,5 +99,5 @@ spec:
             name: hermes-agent-gateway-startup-config
         - name: ssh-key
           secret:
-            secretname: hermes-agent-gateway-ssh
+            secretName hermes-agent-gateway-ssh
             defaultMode: 0400


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* __->__ #1294

Signed-off-by: William Phetsinorath <william.phetsinorath@shikanime.studio>
Change-Id: Id2f396e0350cc58e69a4bb07f6f1bb936a6a6964