### PR TITLE
Fix Hermes agent missing port

### DIFF
--- a/apps/hermes-agent/dashboard/base/sts.yaml
+++ b/apps/hermes-agent/dashboard/base/sts.yaml
@@ -24,6 +24,9 @@ spec:
           env:
             - name: GATEWAY_HEALTH_URL
               value: http://$(HERMES_AGENT_GATEWAY_SERVICE_HOST):$(HERMES_AGENT_GATEWAY_SERVICE_PORT)
+          ports:
+            - containerPort: 9119
+              name: http
           volumeMounts:
             - name: data
               mountPath: /opt/data


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* __->__ #1295

Signed-off-by: William Phetsinorath <william.phetsinorath@shikanime.studio>
Change-Id: I4ea11da00343942e91d5f36b3277fe0c6a6a6964