### PR TITLE
Remove cert manager

### DIFF
--- a/clusters/nishir/overlays/tailnet/ks.yaml
+++ b/clusters/nishir/overlays/tailnet/ks.yaml
@@ -177,7 +177,6 @@ metadata:
   namespace: flux-system
 spec:
   dependsOn:
-    - name: ifrastructure-cert-manager
     - name: infrastructure-vpa
   interval: 10m
   path: ./apps/chrome/overlays/nishir-tailnet


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* __->__ #1312

Signed-off-by: William Phetsinorath <william.phetsinorath@shikanime.studio>
Change-Id: Ie6d7c191c98c89eb85d9d3ee8fdc13746a6a6964