### PR TITLE
Fix Postgres missing fowner cap

### DIFF
--- a/apps/honcho-postgres/base/sts.yaml
+++ b/apps/honcho-postgres/base/sts.yaml
@@ -34,6 +34,7 @@ spec:
             capabilities:
               add:
                 - CHOWN
+                - FOWNER
                 - SETUID
                 - SETGID
                 - DAC_OVERRIDE


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* __->__ #1333
* #1332

Signed-off-by: William Phetsinorath <william.phetsinorath@shikanime.studio>
Change-Id: Iab45d72b3af874ec601652de73505adb6a6a6964