### PR TITLE
Remove Caddy auto https on 80 and 443

### DIFF
--- a/apps/synapse-proxy/base/deploy.yaml
+++ b/apps/synapse-proxy/base/deploy.yaml
@@ -31,8 +31,6 @@ spec:
       containers:
         - name: caddy
           image: caddy
-          securityContext:
-            allowPrivilegeEscalation: true
           ports:
             - name: http
               containerPort: 8008

--- a/apps/synapse-proxy/overlays/nishir-tailnet/synapse-proxy/Caddyfile
+++ b/apps/synapse-proxy/overlays/nishir-tailnet/synapse-proxy/Caddyfile
@@ -54,3 +54,7 @@
 		import matrix
 	}
 }
+
+{
+	auto_https disable_redirects
+}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* __->__ #1335

Signed-off-by: William Phetsinorath <william.phetsinorath@shikanime.studio>
Change-Id: Ia0d93dcf31d0f4a3e94b058a275eab3f6a6a6964