### PR TITLE
Fix Caddy global block must be first

### DIFF
--- a/apps/synapse-proxy/overlays/nishir-tailnet/synapse-proxy/Caddyfile
+++ b/apps/synapse-proxy/overlays/nishir-tailnet/synapse-proxy/Caddyfile
@@ -1,3 +1,7 @@
+{
+	auto_https off
+}
+
 (mautrix) {
 	@isMautrixWellKnown path /.well-known/matrix/mautrix
 	handle @isMautrixWellKnown {
@@ -53,8 +57,4 @@
 	handle {
 		import matrix
 	}
-}
-
-{
-	auto_https off
 }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* #1362
* __->__ #1361

Signed-off-by: William Phetsinorath <william.phetsinorath@shikanime.studio>
Change-Id: I969688008c5ab71fac6e96c024e3ea016a6a6964