### PR TITLE
Add missing Hetzner infrastructure

### DIFF
--- a/infrastructure/cluster-api/base/hr.yaml
+++ b/infrastructure/cluster-api/base/hr.yaml
@@ -30,3 +30,4 @@ spec:
       k0sproject-k0smotron: {}
     infrastructure:
       k0sproject-k0smotron: {}
+      hetzner: {}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* __->__ #1376

Signed-off-by: William Phetsinorath <william.phetsinorath@shikanime.studio>
Change-Id: Ib0d0529a493a8b6cebc08d2ce51eada56a6a6964