### PR TITLE
Remove Shana load balancer

### DIFF
--- a/configs/cluster-api/base/hetzner-cluster.yaml
+++ b/configs/cluster-api/base/hetzner-cluster.yaml
@@ -8,7 +8,7 @@ spec:
     host: "0.0.0.0"
     port: 443
   controlPlaneLoadBalancer:
-    region: fsn1
+    enabled: false
   controlPlaneRegions:
     - fsn1
     - nbg1


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* #1385
* __->__ #1384

Signed-off-by: William Phetsinorath <william.phetsinorath@shikanime.studio>
Change-Id: I9ed87f548c3e58ccbd23ee781bde358d6a6a6964