### PR TITLE
Fix cert-manager missing ks.yaml

### DIFF
--- a/infrastructure/cert-manager/overlays/telsha/kustomization.yaml
+++ b/infrastructure/cert-manager/overlays/telsha/kustomization.yaml
@@ -1,4 +1,3 @@
 ---
 resources:
   - ../../base
-  - ks.yaml


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* __->__ #1398

Signed-off-by: William Phetsinorath <william.phetsinorath@shikanime.studio>
Change-Id: I5ad48ee2898012db071c979322d568226a6a6964