### PR TITLE
Remove qbt cleanup useless dependencies

### DIFF
--- a/clusters/nishir/overlays/tailnet/ks.yaml
+++ b/clusters/nishir/overlays/tailnet/ks.yaml
@@ -537,9 +537,6 @@ metadata:
   name: apps-qbittorrent-cleanup
   namespace: flux-system
 spec:
-  dependsOn:
-    - name: infrastructure-cert-manager
-    - name: infrastructure-vpa
   interval: 10m
   path: ./apps/qbittorrent-cleanup/overlays/nishir-tailnet
   prune: true


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* #1403
* #1402
* __->__ #1401
* #1400
* #1399

Signed-off-by: William Phetsinorath <william.phetsinorath@shikanime.studio>
Change-Id: Ieb5f5560d511f33aede7ed6aeb2e43026a6a6964