### PR TITLE
Remove qbt cleanup digest

### DIFF
--- a/apps/qbittorrent-cleanup/base/kustomization.yaml
+++ b/apps/qbittorrent-cleanup/base/kustomization.yaml
@@ -3,6 +3,5 @@ resources:
   - cronjob.yaml
 images:
   - name: qbittorrent-cleanup
-    digest: sha256:85091f0d6f175ca64f670d61c77925aee6c05c9c53da93270944b7538b6cba1e
     newName: ghcr.io/shikanime/manifests/qbittorrent-cleanup
     newTag: fc533d07d


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* #1408
* #1407
* #1406
* __->__ #1405
* #1404

Signed-off-by: William Phetsinorath <william.phetsinorath@shikanime.studio>
Change-Id: I260a2d820826357bd11a6ca17925865a6a6a6964