### PR TITLE
Remove access logs from Caddy

### DIFF
--- a/apps/synapse-proxy/overlays/nishir-tailnet/synapse-proxy/Caddyfile
+++ b/apps/synapse-proxy/overlays/nishir-tailnet/synapse-proxy/Caddyfile
@@ -37,7 +37,6 @@
 }
 
 :8008 {
-	log
 	@isDiscordDirectMedia host matrix-discord-media.taila659a.ts.net
 	handle @isDiscordDirectMedia {
 		import matrix-discord-media
@@ -49,7 +48,6 @@
 
 :8448 {
 	tls /etc/ssl/private/tls.crt /etc/ssl/private/tls.key
-	log
 	@isDiscordDirectMedia host matrix-discord-media.taila659a.ts.net
 	handle @isDiscordDirectMedia {
 		import matrix-discord-media


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* #1408
* #1407
* __->__ #1406
* #1405
* #1404

Signed-off-by: William Phetsinorath <william.phetsinorath@shikanime.studio>
Change-Id: I7bb92675ca8b7d123392e32f57eb3c316a6a6964