### PR TITLE
Remove nix flake check impure network for CI

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -155,8 +155,7 @@
                             ${pkgs.kubeconform}/bin/kubeconform \
                               -exit-on-error \
                               -strict \
-                              -schema-location default \
-                              -schema-location 'https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json'
+                              -ignore-missing-schemas
                         done
                       '';
                     in


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* __->__ #1417
* #1416
* #1415

Signed-off-by: William Phetsinorath <william.phetsinorath@shikanime.studio>
Change-Id: I6d59437079b24968f41f5af7accee0a66a6a6964