### PR TITLE
Remove dangling qbt job image

### DIFF
--- a/apps/qbittorrent/base/kustomization.yaml
+++ b/apps/qbittorrent/base/kustomization.yaml
@@ -21,6 +21,3 @@ images:
   - name: qbittorrent
     newName: qbittorrentofficial/qbittorrent-nox
     newTag: 5.1.4-2
-  - name: qbittorrent-cleanup
-    newName: ghcr.io/shikanime/manifests/qbittorrent-cleanup
-    newTag: latest


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* __->__ #1427

Signed-off-by: William Phetsinorath <william.phetsinorath@shikanime.studio>
Change-Id: If4f09a7b10f0ea5edc7c3bd3fd4ab9ec6a6a6964