### PR TITLE
Fix xqbit image tag not found

### DIFF
--- a/apps/qbittorrent-cleanup/base/kustomization.yaml
+++ b/apps/qbittorrent-cleanup/base/kustomization.yaml
@@ -3,4 +3,4 @@ resources:
 images:
   - name: qbittorrent-cleanup
     newName: ghcr.io/shikanime/xqbit/qbittorrent-cleanup
-    newTag: fc533d07d
+    newTag: 4e7e1b0


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* __->__ #1454

Signed-off-by: William Phetsinorath <william.phetsinorath@shikanime.studio>
Change-Id: Icd94fc69326e1b6c306d9612cf0d2d106a6a6964