### PR TITLE
Fix documentation point to removed hardware configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,11 +111,6 @@ Most apps follow the same pattern:
 - Secrets/config: stored as `*.enc.*` and fed into `secretGenerator` (see
   [Secrets](#secrets))
 
-Hardware-dependent apps can also add scheduling constraints via components
-(example: [patch-sts.yaml](apps/jellyfin/components/v4l2/patch-sts.yaml)), which
-rely on NFD labels from
-[nodefeature.yaml](configs/nfd/overlays/nishir/nodefeature.yaml).
-
 ### Secrets
 
 Sensitive values are stored encrypted in-repo and materialized at render/apply


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* __->__ #1458

Signed-off-by: William Phetsinorath <william.phetsinorath@shikanime.studio>
Change-Id: I09f7183ca8e7e5c537f58629781b0d836a6a6964