### PR TITLE
Fix Multus macvlan doesn't have mode

### DIFF
--- a/infrastructure/longhorn/overlays/nishir/netattachdef.yaml
+++ b/infrastructure/longhorn/overlays/nishir/netattachdef.yaml
@@ -10,7 +10,6 @@ spec:
       "name": "longhorn-storage",
       "type": "macvlan",
       "master": "enp1s0",
-      "mode": "l2",
       "ipam": {
         "type": "dhcp"
       }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* __->__ #1460

Signed-off-by: William Phetsinorath <william.phetsinorath@shikanime.studio>
Change-Id: Iabcd7ac2947cf4e76214fccc8fd25f9d6a6a6964