### PR TITLE
Fix ephemeral pvc back to correct storageclass

### DIFF
--- a/clusters/nishir/base/pvc.yaml
+++ b/clusters/nishir/base/pvc.yaml
@@ -38,7 +38,7 @@ spec:
   resources:
     requests:
       storage: 64Gi
-  storageClassName: nishir-capacity
+  storageClassName: nishir-ephemeral
   volumeMode: Filesystem
   volumeName: movies-data
   accessModes:
@@ -53,7 +53,7 @@ spec:
   resources:
     requests:
       storage: 64Gi
-  storageClassName: nishir-capacity
+  storageClassName: nishir-ephemeral
   volumeMode: Filesystem
   volumeName: music-data
   accessModes:
@@ -68,7 +68,7 @@ spec:
   resources:
     requests:
       storage: 512Gi
-  storageClassName: nishir-capacity
+  storageClassName: nishir-ephemeral
   volumeMode: Filesystem
   volumeName: shows-data
   accessModes:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* __->__ #1471

Signed-off-by: William Phetsinorath <william.phetsinorath@shikanime.studio>
Change-Id: Ia4a5e3098f2c06183fc91bd09ffb66056a6a6964