### PR TITLE
Migrate VPA to use cert-manager for cert generation

### DIFF
--- a/infrastructure/vpa/base/cert.yaml
+++ b/infrastructure/vpa/base/cert.yaml
@@ -1,0 +1,21 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: vpa-admission-tls
+  namespace: autoscaler-system
+spec:
+  commonName: vpa-admission-controller
+  dnsNames:
+    - vpa-admission-controller
+    - vpa-admission-controller.autoscaler-system
+    - vpa-admission-controller.autoscaler-system.svc
+  duration: 8760h
+  issuerRef:
+    name: nishir
+    kind: ClusterIssuer
+  renewBefore: 720h
+  secretName: vpa-tls-secret
+  usages:
+    - digital signature
+    - key encipherment
+    - server auth

--- a/infrastructure/vpa/base/hr.yaml
+++ b/infrastructure/vpa/base/hr.yaml
@@ -20,3 +20,13 @@ spec:
   interval: 10m
   releaseName: vpa
   targetNamespace: autoscaler-system
+  values:
+    admissionController:
+      generateCertificate: false
+      tlsSecretKeys:
+        - key: ca.crt
+          path: caCert.pem
+        - key: tls.crt
+          path: serverCert.pem
+        - key: tls.key
+          path: serverKey.pem

--- a/infrastructure/vpa/base/kustomization.yaml
+++ b/infrastructure/vpa/base/kustomization.yaml
@@ -1,4 +1,5 @@
 resources:
+  - cert.yaml
   - helmrepo.yaml
   - hr.yaml
   - ns.yaml


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* __->__ #1483

Signed-off-by: William Phetsinorath <william.phetsinorath-open@interieur.gouv.fr>
Change-Id: I4f2edc7de608aab666438b8f9531b98e6a6a6964