### PR TITLE
Fix vmks ingress invalid backend

### DIFF
--- a/infrastructure/victoriametrics/overlays/nishir-tailnet/patch-hr.yaml
+++ b/infrastructure/victoriametrics/overlays/nishir-tailnet/patch-hr.yaml
@@ -15,4 +15,6 @@ spec:
         ingressClassName: tailscale
         path: /
         pathType: Prefix
-        tls: []
+        tls:
+          - hosts:
+              - nishir-grafana


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* #1486
* #1485
* __->__ #1484

Signed-off-by: William Phetsinorath <william.phetsinorath-open@interieur.gouv.fr>
Change-Id: I46f38b59c460d54f09a472adce680b956a6a6964