### PR TITLE
Fix Longhorn ingress path type

### DIFF
--- a/infrastructure/longhorn/overlays/nishir-tailnet/patch-hr.yaml
+++ b/infrastructure/longhorn/overlays/nishir-tailnet/patch-hr.yaml
@@ -21,6 +21,7 @@ spec:
             patch: |
               - op: add
                 path: /spec/tls
+                pathType: Prefix
                 value:
                   - hosts:
                       - nishir-longhorn


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* __->__ #1489

Signed-off-by: William Phetsinorath <william.phetsinorath-open@interieur.gouv.fr>
Change-Id: Ic0b2d6efa71b79b3c98a351b4bb91a6a6a6a6964