### PR TITLE
Fix Jellyfin missing allowPrivilegeEscalation

### DIFF
--- a/apps/jellyfin/overlays/nishir/patch-sts.yaml
+++ b/apps/jellyfin/overlays/nishir/patch-sts.yaml
@@ -8,6 +8,7 @@ spec:
       containers:
         - name: jellyfin
           securityContext:
+            allowPrivilegeEscalation: true
             privileged: true
           volumeMounts:
             - name: dev-dri


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* __->__ #1531

Signed-off-by: William Phetsinorath <william.phetsinorath-open@interieur.gouv.fr>
Change-Id: Ie7dae97ffa073a6fe5a9d57594a59e7e6a6a6964