### PR TITLE
fix: add missing netpols for vaultwarden and catbox; fix jellyfin port reference

### DIFF
--- a/apps/catbox/base/kustomization.yaml
+++ b/apps/catbox/base/kustomization.yaml
@@ -1,4 +1,5 @@
 resources:
+  - netpol.yaml
   - pvc.yaml
   - sts.yaml
   - svc.yaml

--- a/apps/catbox/base/netpol.yaml
+++ b/apps/catbox/base/netpol.yaml
@@ -1,0 +1,14 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: catbox
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/instance: catbox
+      app.kubernetes.io/name: catbox
+  policyTypes:
+    - Ingress
+  ingress:
+    - ports:
+        - port: ssh

--- a/apps/jellyfin/base/netpol.yaml
+++ b/apps/jellyfin/base/netpol.yaml
@@ -27,4 +27,4 @@ spec:
             matchLabels:
               app.kubernetes.io/name: whisparr
       ports:
-        - port: https
+        - port: http

--- a/apps/vaultwarden/base/kustomization.yaml
+++ b/apps/vaultwarden/base/kustomization.yaml
@@ -1,4 +1,5 @@
 resources:
+  - netpol.yaml
   - pvc.yaml
   - sts.yaml
   - svc.yaml

--- a/apps/vaultwarden/base/netpol.yaml
+++ b/apps/vaultwarden/base/netpol.yaml
@@ -1,0 +1,14 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: vaultwarden
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/instance: vaultwarden
+      app.kubernetes.io/name: vaultwarden
+  policyTypes:
+    - Ingress
+  ingress:
+    - ports:
+        - port: http


### PR DESCRIPTION
## Summary
- Add `netpol.yaml` and kustomization entry for **vaultwarden** (was missing)
- Add `netpol.yaml` and kustomization entry for **catbox** (was missing)
- Fix jellyfin base netpol to reference port `http` instead of `https`
  - The `https` port (8920) is only added by the TLS component overlay

## Security
Vaultwarden and catbox services were exposed without any NetworkPolicy restricting ingress. This adds baseline network policies.