### PR TITLE
Add missing netpol for vaultwarden

### DIFF
--- a/apps/vaultwarden/base/kustomization.yaml
+++ b/apps/vaultwarden/base/kustomization.yaml
@@ -1,4 +1,5 @@
 resources:
+  - netpol.yaml
   - pvc.yaml
   - sts.yaml
   - svc.yaml

--- a/apps/vaultwarden/base/netpol.yaml
+++ b/apps/vaultwarden/base/netpol.yaml
@@ -1,0 +1,14 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: vaultwarden
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/instance: vaultwarden
+      app.kubernetes.io/name: vaultwarden
+  policyTypes:
+    - Ingress
+  ingress:
+    - ports:
+        - port: http


### PR DESCRIPTION
Add a missing NetworkPolicy for the vaultwarden application.

Previously, vaultwarden was exposed without any NetworkPolicy restricting ingress traffic. This adds a baseline policy allowing ingress on the `http` port (80), which is the only port exposed by the vaultwarden service.

This is the first in a stack of netpol fixes for apps that were missing network policies.

Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* #1548
* #1547
* __->__ #1546