### PR TITLE
Add missing netpol for catbox

### DIFF
--- a/apps/catbox/base/kustomization.yaml
+++ b/apps/catbox/base/kustomization.yaml
@@ -1,4 +1,5 @@
 resources:
+  - netpol.yaml
   - pvc.yaml
   - sts.yaml
   - svc.yaml

--- a/apps/catbox/base/netpol.yaml
+++ b/apps/catbox/base/netpol.yaml
@@ -1,0 +1,14 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: catbox
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/instance: catbox
+      app.kubernetes.io/name: catbox
+  policyTypes:
+    - Ingress
+  ingress:
+    - ports:
+        - port: ssh


### PR DESCRIPTION
Add a missing NetworkPolicy for the catbox application.

Previously, catbox was exposed without any NetworkPolicy restricting ingress traffic. This adds a baseline policy allowing ingress on the `ssh` port (22), which is the only port exposed by the catbox service.

This is the second in a stack of netpol fixes.

Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* #1548
* __->__ #1547
* #1546