### PR TITLE
Fix jellyfin netpol port reference

### DIFF
--- a/apps/jellyfin/base/netpol.yaml
+++ b/apps/jellyfin/base/netpol.yaml
@@ -27,4 +27,4 @@ spec:
             matchLabels:
               app.kubernetes.io/name: whisparr
       ports:
-        - port: https
+        - port: http


### PR DESCRIPTION
Fix the jellyfin base NetworkPolicy to reference the correct port.

The base netpol was referencing port `https` (8920), but the base StatefulSet only exposes port `http` (8096). The `https` port is only added by the TLS component overlay. This meant the base netpol would never match any traffic without the TLS component applied.

This is the third in a stack of netpol fixes.

Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* __->__ #1548
* #1547
* #1546