### PR TITLE
Add missing network policy for vaultwarden

### DIFF
--- a/apps/vaultwarden/base/kustomization.yaml
+++ b/apps/vaultwarden/base/kustomization.yaml
@@ -1,4 +1,5 @@
 resources:
+  - netpol.yaml
   - pvc.yaml
   - sts.yaml
   - svc.yaml

--- a/apps/vaultwarden/base/netpol.yaml
+++ b/apps/vaultwarden/base/netpol.yaml
@@ -1,0 +1,14 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: vaultwarden
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/instance: vaultwarden
+      app.kubernetes.io/name: vaultwarden
+  policyTypes:
+    - Ingress
+  ingress:
+    - ports:
+        - port: http

--- a/apps/vaultwarden/base/netpol.yaml
+++ b/apps/vaultwarden/base/netpol.yaml
@@ -10,5 +10,9 @@ spec:
   policyTypes:
     - Ingress
   ingress:
-    - ports:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: tailscale-system
+      ports:
         - port: http


### PR DESCRIPTION
## Summary

Add a baseline NetworkPolicy for vaultwarden that restricts ingress to the Tailscale ingress controller namespace.

## Changes

- Create `apps/vaultwarden/base/netpol.yaml` — allows inbound traffic on the `http` port from the `tailscale-system` namespace only
- Reference the new netpol in `apps/vaultwarden/base/kustomization.yaml`

## Context

Previously, vaultwarden had no base network policy, meaning all intra-cluster ingress was unrestricted. This follows the same pattern as other apps with Tailscale ingress (e.g. forgejo, copyparty, jellyfin) which use a `namespaceSelector` targeting `tailscale-system` to restrict base ingress to Tailscale-proxied traffic.