### PR TITLE
Add missing network policy for vaultwarden

### DIFF
--- a/apps/vaultwarden/base/kustomization.yaml
+++ b/apps/vaultwarden/base/kustomization.yaml
@@ -1,4 +1,5 @@
 resources:
+  - netpol.yaml
   - pvc.yaml
   - sts.yaml
   - svc.yaml

--- a/apps/vaultwarden/base/netpol.yaml
+++ b/apps/vaultwarden/base/netpol.yaml
@@ -1,0 +1,18 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: vaultwarden
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/instance: vaultwarden
+      app.kubernetes.io/name: vaultwarden
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: tailscale-system
+      ports:
+        - port: http


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* #1554
* #1553
* __->__ #1552

Create a baseline NetworkPolicy that restricts ingress to the Tailscale
ingress controller namespace (tailscale-system). This follows the same
pattern as other Tailscale-exposed apps (forgejo, copyparty, jellyfin).

The policy allows inbound traffic on the http port from tailscale-system
only, preventing unrestricted intra-cluster access.