### PR TITLE
Add missing network policy for catbox

### DIFF
--- a/apps/catbox/base/kustomization.yaml
+++ b/apps/catbox/base/kustomization.yaml
@@ -1,4 +1,5 @@
 resources:
+  - netpol.yaml
   - pvc.yaml
   - sts.yaml
   - svc.yaml

--- a/apps/catbox/base/netpol.yaml
+++ b/apps/catbox/base/netpol.yaml
@@ -1,0 +1,19 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: catbox
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/instance: catbox
+      app.kubernetes.io/name: catbox
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: tailscale-system
+      ports:
+        - port: ssh
+        - port: mdns


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* #1554
* __->__ #1553
* #1552

Create a baseline NetworkPolicy that restricts ingress to the Tailscale
ingress controller namespace (tailscale-system). This follows the same
pattern as other Tailscale-exposed apps.

The policy allows inbound traffic on the ssh and mdns ports from
tailscale-system only, preventing unrestricted intra-cluster access.