### PR TITLE
Fix jellyfin netpol port reference

### DIFF
--- a/apps/jellyfin/base/netpol.yaml
+++ b/apps/jellyfin/base/netpol.yaml
@@ -27,4 +27,4 @@ spec:
             matchLabels:
               app.kubernetes.io/name: whisparr
       ports:
-        - port: https
+        - port: http


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* __->__ #1554
* #1553
* #1552

Change the allowed ingress port from https to http to match the
jellyfin service definition. The servarr apps (lidarr, radarr,
sonarr, whisparr, seerr) connect to jellyfin via the http port
internally.