### PR TITLE
Add branch naming enforcement CI workflow

### DIFF
--- a/.github/scripts/check-branch-naming.sh
+++ b/.github/scripts/check-branch-naming.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BRANCH="${GITHUB_HEAD_REF:-${GITHUB_REF_NAME:-$(git rev-parse --abbrev-ref HEAD)}}"
+
+# Skip check for trunk and protected branches
+if [[ "$BRANCH" =~ ^(main|master)$ ]]; then
+  echo "OK: trunk branch '$BRANCH'"
+  exit 0
+fi
+
+# Skip check for release branches
+if [[ "$BRANCH" =~ ^release-[a-zA-Z0-9._-]+$ ]]; then
+  echo "OK: release branch '$BRANCH'"
+  exit 0
+fi
+
+# Skip check for ghstack branches
+if [[ "$BRANCH" =~ ^gh/[a-zA-Z0-9._-]+/[0-9]+/(base|head|orig)$ ]]; then
+  echo "OK: ghstack branch '$BRANCH'"
+  exit 0
+fi
+
+# Skip for bots (Renovate, Dependabot, etc.)
+if [[ "$BRANCH" =~ ^(renovate|dependabot|actions|pre-commit-ci)/ ]]; then
+  echo "OK: bot branch '$BRANCH'"
+  exit 0
+fi
+
+echo "ERROR: Branch '$BRANCH' does not match allowed patterns."
+echo ""
+echo "Allowed patterns:"
+echo "  - main | master (trunk)"
+echo "  - release-<name> (release branches)"
+echo "  - gh/<user>/<N>/{base,head,orig} (ghstack branches)"
+echo "  - renovate/* | dependabot/* | actions/* | pre-commit-ci/* (bot branches)"
+echo ""
+echo "Please use the ghstack workflow: jj commit -m 'description' → ghstack"
+exit 1

--- a/.github/workflows/check-branch-naming.yaml
+++ b/.github/workflows/check-branch-naming.yaml
@@ -1,0 +1,18 @@
+name: Check branch naming
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+  push:
+    branches-ignore:
+      - main
+      - master
+
+permissions: {}
+
+jobs:
+  check-branch:
+    runs-on: ubuntu-slim
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - name: Validate branch name
+        run: bash .github/scripts/check-branch-naming.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,6 +58,15 @@ the flake evaluates.
   (example: `.enc.env` → `.env`).
 - Never commit decrypted outputs. Change the encrypted source instead.
 
+## Branch Naming
+
+- **Trunk**: `main`
+- **Release branches**: `release-<name>` (e.g. `release-1.0`, `release-unstable`)
+- **Feature/fix branches**: use ghstack workflow only — branches named `gh/<user>/<N>/{base,head,orig}`
+- **Bot branches**: `renovate/*`, `dependabot/*`, `actions/*`, `pre-commit-ci/*` are allowed
+
+Do not create bare feature/fix branches (e.g. `fix/something`, `feature/xyz`). Use `jj commit` + `ghstack` instead.
+
 ## Conventions
 
 - Always add probes for workloads: `readinessProbe`, `livenessProbe`, and


### PR DESCRIPTION
Add CI workflow to enforce branch naming conventions.

Allowed patterns:
- main (trunk)
- release-* (release branches)
- gh/<user>/<N>/{base,head,orig} (ghstack branches)
- renovate/*, dependabot/*, etc. (bot branches)

This is a CI-based enforcement for user-owned repos where GitHub rulesets don't support branch_name_pattern. Org repos (shikanime-studio/*) use ruleset-level enforcement.