### PR TITLE
Add OpenLDAP manifests for LDAPS-enabled directory server

### DIFF
--- a/apps/openldap/base/cert.yaml
+++ b/apps/openldap/base/cert.yaml
@@ -1,0 +1,20 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: openldap
+spec:
+  secretName: openldap-tls
+  duration: 2160h
+  renewBefore: 720h
+  isCA: false
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  usages:
+    - server auth
+  dnsNames:
+    - openldap
+    - openldap.shikanime.svc.cluster.local
+  issuerRef:
+    name: nishir
+    kind: ClusterIssuer

--- a/apps/openldap/base/kustomization.yaml
+++ b/apps/openldap/base/kustomization.yaml
@@ -1,0 +1,6 @@
+resources:
+  - sts.yaml
+  - svc.yaml
+  - pvc.yaml
+  - cert.yaml
+  - netpol.yaml

--- a/apps/openldap/base/netpol.yaml
+++ b/apps/openldap/base/netpol.yaml
@@ -1,0 +1,16 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: openldap
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/instance: openldap
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: shikanime
+      ports:
+        - port: ldap
+        - port: ldaps

--- a/apps/openldap/base/pvc.yaml
+++ b/apps/openldap/base/pvc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: openldap
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: longhorn
+  resources:
+    requests:
+      storage: 5Gi

--- a/apps/openldap/base/sts.yaml
+++ b/apps/openldap/base/sts.yaml
@@ -1,0 +1,72 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: openldap
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: openldap
+      app.kubernetes.io/name: openldap
+  serviceName: openldap
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/instance: openldap
+        app.kubernetes.io/name: openldap
+    spec:
+      securityContext:
+        fsGroup: 1001
+      initContainers:
+        - name: tls-cert
+          image: alpine:3.20
+          command:
+            - sh
+            - -c
+            - |
+              cp /tls/tls.crt /certs/tls.crt
+              cp /tls/tls.key /certs/tls.key
+              chmod 600 /certs/tls.key
+          volumeMounts:
+            - name: tls-secret
+              mountPath: /tls
+            - name: certs
+              mountPath: /certs
+      containers:
+        - name: openldap
+          image: osixia/openldap:1.5.0
+          ports:
+            - name: ldap
+              containerPort: 389
+            - name: ldaps
+              containerPort: 636
+          envFrom:
+            - secretRef:
+                name: openldap
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/ldap
+            - name: data
+              mountPath: /etc/ldap/slapd.d
+              subPath: config
+            - name: certs
+              mountPath: /container/service/slapd/assets/certs
+          livenessProbe:
+            tcpSocket:
+              port: ldaps
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          readinessProbe:
+            tcpSocket:
+              port: ldaps
+            initialDelaySeconds: 10
+            periodSeconds: 5
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: openldap
+        - name: certs
+          emptyDir: {}
+        - name: tls-secret
+          secret:
+            secretName: openldap-tls

--- a/apps/openldap/base/svc.yaml
+++ b/apps/openldap/base/svc.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: openldap
+spec:
+  ports:
+    - name: ldap
+      port: 389
+      targetPort: ldap
+    - name: ldaps
+      port: 636
+      targetPort: ldaps
+  selector:
+    app.kubernetes.io/instance: openldap
+    app.kubernetes.io/name: openldap

--- a/apps/openldap/overlays/nishir/.enc.env
+++ b/apps/openldap/overlays/nishir/.enc.env
@@ -1,0 +1,16 @@
+LDAP_ORGANISATIONS=ENC[AES256_GCM,data:txhjGQ44GMLTs4zCJ5oJVg==,iv:iMkMWsiQDfFTshvyG/OksKHQV/OeiAABocroLw4Finw=,tag:bXkKk9gYvViIgynP4t6n8g==,type:str]
+LDAP_DOMAIN=ENC[AES256_GCM,data:H4HXKInT2+nNmT2C29dkxg==,iv:fQMrbyKFG1qvth9+8xikSS7kueU9I/ae/pagGcXGWAM=,tag:8XlXIi0LIlDO+r13m5lJsQ==,type:str]
+LDAP_ADMIN_PASSWORD=ENC[AES256_GCM,data:RZyO,iv:Lx/M5VZTz1t7Meh1EY+3f3Hs6wytfIh0a3ujorTK+eI=,tag:W1pVpf6lXPp4CscteAd6wQ==,type:str]
+LDAP_CONFIG_PASSWORD=ENC[AES256_GCM,data:ohXx,iv:GJica2vNC4nRaIebFQfz6SSyUoDsnWbef1N5/LJ36nY=,tag:jL1E841YcfU+lyB8NB138w==,type:str]
+LDAP_TLS=ENC[AES256_GCM,data:nZaSFA==,iv:YBFwIBRZBvN+Lvzjkq/nMe48Y3Nft1zhB1buy8IdQpo=,tag:zw5vfDj+JPimb1i3r8ZEyQ==,type:str]
+LDAP_TLS_ENFORCE=ENC[AES256_GCM,data:sCz7sw==,iv:Dr1548q4BL348nW5ZnlCvZVIB1g+77fdwGC3rXZ5eGc=,tag:hieeRghakP7dbDk9u9TQ9g==,type:str]
+LDAP_TLS_CRT_FILENAME=ENC[AES256_GCM,data:OLDKaOr7GQ==,iv:l4LN1g76Qw4MyIG58tACiK08T/R54vDeuOGSV2KJJKs=,tag:Wa6Q6SINJz4DmWEoAJIf0A==,type:str]
+LDAP_TLS_KEY_FILENAME=ENC[AES256_GCM,data:ByZReVCTdw==,iv:1017pgSjcr9kvHwdLhNz+Y4M87OBdRgYZx7OyBHwsCM=,tag:OJBxLJMjQtDAJTd7i91UnQ==,type:str]
+LDAP_TLS_CA_CRT_FILENAME=
+LDAP_READONLY_USER=ENC[AES256_GCM,data:64prVq0=,iv:MhiUpSs0Qf8hX0cz5zyDFxERDub5aaRMpFKmvB545oM=,tag:TcpbkiNTnMhcwi0L6fCHdw==,type:str]
+sops_age__list_0__map_enc=-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBHcXFqTFdwMXgzM2VmQU52\nL3k3RVBKaWpPZS9NcERCUGZpVlE2UEVsRDJZCjZUNllUSDhzQUc3NzkrazVBSktS\nYTJiTCt5aWVvdmc1cUVPbXF6aS9mb0EKLS0tIFphaFhmQWcvWFVkendISm9nTnUw\naml3TDNPUHFMTVB1czVvclZ2Vy9jMlUKqGjZvNYhA40qO+wGVTPEbx8tY1fR1YYg\n6FVOWMBwgBojyEXSdUpasZzPdt17nowlySlLfsR8jBv5DhZeu1rwjw==\n-----END AGE ENCRYPTED FILE-----\n
+sops_age__list_0__map_recipient=age139fcg32lmhxupnz5wjex44jur7v7wzf9rttp2grnjmxhukck5dmqsd9zj5
+sops_lastmodified=2026-06-15T17:45:09Z
+sops_mac=ENC[AES256_GCM,data:0o5fB9mU+m7vQhdGeVbf2cHHrKN9yxK3WT94swSd3y6mcrsW5qUP4LSHwlXIUpSBl9ZtuIp/bVFbmTwbKWZGVmTQ32EyIOdtduaJbzRzKEM306DVOpRyJ8bLhvj4feA3F1DxZ7EluYe5qWGwCDTEcNGk5+wI0Te2njtn42RMNNw=,iv:rAbtIzATfL+TicJgJiaPG0Nc0SqeBCPTLvtGYd2AuRQ=,tag:TXniVy6x3hLGV17mjnaBHg==,type:str]
+sops_unencrypted_suffix=_unencrypted
+sops_version=3.13.1

--- a/apps/openldap/overlays/nishir/kustomization.yaml
+++ b/apps/openldap/overlays/nishir/kustomization.yaml
@@ -1,0 +1,7 @@
+resources:
+  - ../../base
+namespace: shikanime
+secretGenerator:
+  - name: openldap
+    envs:
+      - .enc.env


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #1572
* #1571
* #1570
* #1569
* #1568
* #1567
* #1566
* #1565
* #1564
* #1563
* #1562
* #1561
* #1560
* #1559
* #1558
* #1557
* __->__ #1556

Design:
- OpenLDAP (osixia/openldap:1.5.0) with LDAPS on port 636
- cert-manager Certificate using the nishir ClusterIssuer
- Init-container copies TLS cert to the expected path
- Probes check ldaps port
- PVC on Longhorn for persistent data
- SOPS-encrypted admin and config passwords
- NetworkPolicy restricted to shikanime namespace