### PR TITLE
Add Dex base manifests with SQLite storage and LDAPS connector

### DIFF
--- a/apps/dex/base/deploy.yaml
+++ b/apps/dex/base/deploy.yaml
@@ -1,0 +1,58 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dex
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: dex
+      app.kubernetes.io/name: dex
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/instance: dex
+        app.kubernetes.io/name: dex
+    spec:
+      containers:
+        - name: dex
+          image: ghcr.io/dexidp/dex:v2.41.1
+          args:
+            - serve
+            - /etc/dex/config.yaml
+          ports:
+            - name: http
+              containerPort: 5556
+          volumeMounts:
+            - name: config
+              mountPath: /etc/dex
+            - name: data
+              mountPath: /var/dex
+            - name: openldap-ca
+              mountPath: /etc/dex/openldap-ca
+              readOnly: true
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 5
+      volumes:
+        - name: config
+          secret:
+            secretName: dex
+        - name: data
+          persistentVolumeClaim:
+            claimName: dex
+        - name: openldap-ca
+          secret:
+            secretName: openldap-tls
+            items:
+              - key: tls.crt
+                path: ca.crt

--- a/apps/dex/base/kustomization.yaml
+++ b/apps/dex/base/kustomization.yaml
@@ -1,0 +1,5 @@
+resources:
+  - deploy.yaml
+  - svc.yaml
+  - pvc.yaml
+  - netpol.yaml

--- a/apps/dex/base/netpol.yaml
+++ b/apps/dex/base/netpol.yaml
@@ -1,0 +1,15 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: dex
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/instance: dex
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: shikanime
+      ports:
+        - port: http

--- a/apps/dex/base/pvc.yaml
+++ b/apps/dex/base/pvc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: dex
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: longhorn
+  resources:
+    requests:
+      storage: 2Gi

--- a/apps/dex/base/svc.yaml
+++ b/apps/dex/base/svc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: dex
+spec:
+  ports:
+    - name: http
+      port: 5556
+      targetPort: http
+  selector:
+    app.kubernetes.io/instance: dex
+    app.kubernetes.io/name: dex


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #1572
* #1571
* #1570
* #1569
* #1568
* #1567
* #1566
* #1565
* #1564
* #1563
* #1562
* #1561
* #1560
* #1559
* __->__ #1558
* #1557
* #1556

Design:
- Dex v2.41.1 with SQLite3 storage on Longhorn PVC (2Gi)
- LDAP connector targets openldap:636 with CA cert verification
- OpenLDAP CA cert mounted from openldap-tls secret
- NetworkPolicy restricted to shikanime namespace