### PR TITLE
fix: update xqbit GHCR image path to x-shikanime org

### DIFF
--- a/apps/qbittorrent-cleanup/base/kustomization.yaml
+++ b/apps/qbittorrent-cleanup/base/kustomization.yaml
@@ -2,7 +2,7 @@ resources:
   - cronjob.yaml
 images:
   - name: qbittorrent-cleanup
-    newName: ghcr.io/shikanime/xqbit/qbittorrent-cleanup
+    newName: ghcr.io/x-shikanime/xqbit/qbittorrent-cleanup
     newTag: 4e7e1b0
 metadata:
   annotations:


### PR DESCRIPTION
The kustomization.yaml was still referencing `ghcr.io/shikanime/xqbit/qbittorrent-cleanup` instead of `ghcr.io/x-shikanime/xqbit/qbittorrent-cleanup`. This would cause image pull failures since the xqbit repo has been migrated to the x-shikanime org.