### PR TITLE
Add github-repository tofu module with hardened defaults

### DIFF
--- a/bootstraps/shikanime/github/main.tf
+++ b/bootstraps/shikanime/github/main.tf
@@ -1,0 +1,66 @@
+terraform {
+  required_version = "~> 1.8"
+
+  required_providers {
+    github = {
+      source  = "integrations/github"
+      version = "~> 6.6"
+    }
+  }
+}
+
+module "github_repository" {
+  source = "../../modules/github-repository"
+
+  name        = "shikanime"
+  description = "Shikanime Studio — infrastructure and tooling"
+  visibility  = "public"
+
+  topics = [
+    "nixos",
+    "kubernetes",
+    "gitops",
+    "infrastructure",
+  ]
+
+  has_issues      = true
+  has_discussions = false
+  has_projects    = true
+  has_wiki        = false
+
+  allow_merge_commit = false
+  allow_squash_merge = true
+  allow_rebase_merge = false
+
+  delete_branch_on_merge      = true
+  web_commit_signoff_required = true
+
+  vulnerability_alerts                   = true
+  enable_advanced_security               = true
+  enable_secret_scanning_push_protection = true
+
+  default_branch        = "main"
+  protect_default_branch = true
+
+  required_approving_review_count = 1
+  dismiss_stale_reviews           = true
+  require_code_owner_reviews      = false
+  require_last_push_approval      = true
+
+  enforce_admins                  = true
+  require_signed_commits          = true
+  require_linear_history         = true
+  require_conversation_resolution = true
+
+  allows_force_pushes = false
+  allows_deletions    = false
+  lock_branch         = false
+
+  archive_on_destroy = true
+  prevent_destroy    = true
+
+  enable_enhanced_rulesets = true
+
+  restricted_file_extensions = [".exe", ".dll", ".so", ".dylib"]
+  max_file_size_mb           = 100
+}

--- a/modules/github-repository/outputs.tf
+++ b/modules/github-repository/outputs.tf
@@ -1,0 +1,67 @@
+output "repository_id" {
+  value       = github_repository.this.id
+  description = "GitHub repository ID"
+}
+
+output "repository_node_id" {
+  value       = github_repository.this.node_id
+  description = "GitHub repository GraphQL node ID"
+}
+
+output "repository_name" {
+  value       = github_repository.this.name
+  description = "Repository name"
+}
+
+output "repository_full_name" {
+  value       = github_repository.this.full_name
+  description = "Repository full name (org/name)"
+}
+
+output "repository_html_url" {
+  value       = github_repository.this.html_url
+  description = "Repository HTML URL"
+}
+
+output "repository_ssh_clone_url" {
+  value       = github_repository.this.ssh_clone_url
+  description = "Repository SSH clone URL"
+}
+
+output "repository_http_clone_url" {
+  value       = github_repository.this.http_clone_url
+  description = "Repository HTTP clone URL"
+}
+
+output "repository_default_branch" {
+  value       = github_branch_default.this.branch
+  description = "Default branch name"
+}
+
+output "repository_private" {
+  value       = github_repository.this.private
+  description = "Whether the repository is private"
+}
+
+output "repository_visibility" {
+  value       = github_repository.this.visibility
+  description = "Repository visibility"
+}
+
+output "default_branch_protection_id" {
+  value       = var.protect_default_branch ? github_branch_protection.default[0].id : null
+  description = "Default branch protection rule ID"
+}
+
+output "additional_branch_protection_ids" {
+  value       = { for k, v in github_branch_protection.additional : k => v.id }
+  description = "Map of additional branch protection rule IDs by pattern"
+}
+
+output "ruleset_ids" {
+  value = var.enable_enhanced_rulesets ? {
+    branch = github_repository_ruleset.default_branch[0].id
+    push   = length(github_repository_ruleset.push_restrictions) > 0 ? github_repository_ruleset.push_restrictions[0].id : null
+  } : null
+  description = "Repository ruleset IDs (null if enhanced rulesets disabled)"
+}

--- a/modules/github-repository/repository.tf
+++ b/modules/github-repository/repository.tf
@@ -1,0 +1,177 @@
+resource "github_repository" "this" {
+  name        = var.name
+  description = var.description
+  visibility  = var.visibility
+
+  homepage_url                = var.homepage_url
+  topics                      = var.topics
+  has_issues                  = var.has_issues
+  has_discussions             = var.has_discussions
+  has_projects                = var.has_projects
+  has_wiki                    = var.has_wiki
+  is_template                 = var.is_template
+  allow_merge_commit          = var.allow_merge_commit
+  allow_squash_merge          = var.allow_squash_merge
+  allow_rebase_merge          = var.allow_rebase_merge
+  allow_auto_merge            = var.allow_auto_merge
+  allow_update_branch         = var.allow_update_branch
+  delete_branch_on_merge      = var.delete_branch_on_merge
+  web_commit_signoff_required = var.web_commit_signoff_required
+  auto_init                   = var.auto_init
+  gitignore_template          = var.gitignore_template != "" ? var.gitignore_template : null
+  license_template            = var.license_template != "" ? var.license_template : null
+  archive_on_destroy          = var.archive_on_destroy
+  vulnerability_alerts        = var.vulnerability_alerts
+
+  squash_merge_commit_title   = var.squash_merge_commit_title
+  squash_merge_commit_message = var.squash_merge_commit_message
+
+  dynamic "pages" {
+    for_each = var.pages != null ? [var.pages] : []
+    content {
+      build_type = pages.value.build_type
+      cname      = pages.value.cname
+
+      dynamic "source" {
+        for_each = pages.value.source != null ? [pages.value.source] : []
+        content {
+          branch = source.value.branch
+          path   = source.value.path
+        }
+      }
+    }
+  }
+
+  dynamic "template" {
+    for_each = var.template != null ? [var.template] : []
+    content {
+      owner                = template.value.owner
+      repository           = template.value.repository
+      include_all_branches = template.value.include_all_branches
+    }
+  }
+
+  security_and_analysis {
+    advanced_security {
+      status = var.enable_advanced_security ? "enabled" : "disabled"
+    }
+
+    secret_scanning {
+      status = var.enable_advanced_security ? "enabled" : "disabled"
+    }
+
+    secret_scanning_push_protection {
+      status = var.enable_secret_scanning_push_protection ? "enabled" : "disabled"
+    }
+  }
+
+  lifecycle {
+    ignore_changes = [
+      security_and_analysis, # GHAS settings drift when org-level defaults change
+    ]
+    prevent_destroy = var.prevent_destroy
+  }
+}
+
+resource "github_branch_default" "this" {
+  repository = github_repository.this.name
+  branch     = var.default_branch
+}
+
+resource "github_branch_protection" "default" {
+  count = var.protect_default_branch ? 1 : 0
+
+  repository_id = github_repository.this.node_id
+  pattern       = var.default_branch
+
+  enforce_admins                  = var.enforce_admins
+  require_signed_commits          = var.require_signed_commits
+  required_linear_history         = var.require_linear_history
+  require_conversation_resolution = var.require_conversation_resolution
+  allows_deletions                = var.allows_deletions
+  allows_force_pushes             = var.allows_force_pushes
+  lock_branch                     = var.lock_branch
+
+  required_pull_request_reviews {
+    dismiss_stale_reviews           = var.dismiss_stale_reviews
+    restrict_dismissals             = var.restrict_dismissals
+    dismissal_restrictions          = var.dismissal_restrictions
+    require_code_owner_reviews      = var.require_code_owner_reviews
+    required_approving_review_count = var.required_approving_review_count
+    require_last_push_approval      = var.require_last_push_approval
+  }
+
+  restrict_pushes {
+    push_allowances = var.push_allowances
+  }
+
+  force_push_bypassers = var.force_push_bypassers
+
+  dynamic "required_status_checks" {
+    for_each = length(var.required_status_check_contexts) > 0 ? [1] : []
+    content {
+      strict   = var.required_status_checks_strict
+      contexts = var.required_status_check_contexts
+    }
+  }
+
+  dynamic "required_deployments" {
+    for_each = length(var.required_deployment_environments) > 0 ? [1] : []
+    content {
+      required_deployment_environments = var.required_deployment_environments
+    }
+  }
+
+  lifecycle {
+    prevent_destroy = var.prevent_destroy
+  }
+}
+
+resource "github_branch_protection" "additional" {
+  for_each = { for bp in var.additional_branch_protections : bp.pattern => bp }
+
+  repository_id = github_repository.this.node_id
+  pattern       = each.value.pattern
+
+  enforce_admins                  = each.value.enforce_admins
+  require_signed_commits          = each.value.require_signed_commits
+  required_linear_history         = each.value.required_linear_history
+  require_conversation_resolution = each.value.require_conversation_resolution
+  allows_deletions                = each.value.allows_deletions
+  allows_force_pushes             = each.value.allows_force_pushes
+  lock_branch                     = each.value.lock_branch
+
+  required_pull_request_reviews {
+    dismiss_stale_reviews           = each.value.dismiss_stale_reviews
+    restrict_dismissals             = each.value.restrict_dismissals
+    dismissal_restrictions          = each.value.dismissal_restrictions
+    require_code_owner_reviews      = each.value.require_code_owner_reviews
+    required_approving_review_count = each.value.required_approving_review_count
+    require_last_push_approval      = each.value.require_last_push_approval
+  }
+
+  restrict_pushes {
+    push_allowances = each.value.push_allowances
+  }
+
+  force_push_bypassers = each.value.force_push_bypassers
+
+  dynamic "required_status_checks" {
+    for_each = length(each.value.required_status_check_contexts) > 0 ? [1] : []
+    content {
+      strict   = each.value.required_status_checks_strict
+      contexts = each.value.required_status_check_contexts
+    }
+  }
+
+  dynamic "required_deployments" {
+    for_each = length(each.value.required_deployment_environments) > 0 ? [1] : []
+    content {
+      required_deployment_environments = each.value.required_deployment_environments
+    }
+  }
+
+  lifecycle {
+    prevent_destroy = var.prevent_destroy
+  }
+}

--- a/modules/github-repository/ruleset.tf
+++ b/modules/github-repository/ruleset.tf
@@ -1,0 +1,138 @@
+locals {
+  rule_bypass_actors = [
+    for actor in var.ruleset_bypass_actors : {
+      actor_id    = actor.actor_id
+      actor_type  = actor.actor_type
+      bypass_mode = actor.bypass_mode
+    }
+  ]
+
+  allowed_merge_methods = compact([
+    var.allow_merge_commit ? "merge" : "",
+    var.allow_squash_merge ? "squash" : "",
+    var.allow_rebase_merge ? "rebase" : "",
+  ])
+}
+
+resource "github_repository_ruleset" "default_branch" {
+  count = var.enable_enhanced_rulesets ? 1 : 0
+
+  name        = "${var.name}-branch-rules"
+  repository  = github_repository.this.name
+  target      = "branch"
+  enforcement = "active"
+
+  conditions {
+    ref_name {
+      include = ["~ALL"]
+      exclude = []
+    }
+  }
+
+  dynamic "bypass_actors" {
+    for_each = local.rule_bypass_actors
+    content {
+      actor_id    = bypass_actors.value.actor_id
+      actor_type  = bypass_actors.value.actor_type
+      bypass_mode = bypass_actors.value.bypass_mode
+    }
+  }
+
+  rules {
+    creation                = true
+    update                  = true
+    deletion                = true
+    required_linear_history = var.require_linear_history
+    required_signatures     = var.require_signed_commits
+    non_fast_forward        = !var.allows_force_pushes
+
+    pull_request {
+      allowed_merge_methods           = local.allowed_merge_methods
+      dismiss_stale_reviews_on_push   = var.dismiss_stale_reviews
+      require_code_owner_review       = var.require_code_owner_reviews
+      require_last_push_approval      = var.require_last_push_approval
+      required_approving_review_count = var.required_approving_review_count
+    }
+
+    dynamic "required_deployments" {
+      for_each = length(var.required_deployment_environments) > 0 ? [1] : []
+      content {
+        required_deployment_environments = var.required_deployment_environments
+      }
+    }
+
+    dynamic "required_status_checks" {
+      for_each = length(var.required_status_check_contexts) > 0 ? [1] : []
+      content {
+        strict_required_check_suite_configurations = []
+        strict_required_status_checks_policy       = var.required_status_checks_strict
+        required_status_checks = [
+          for ctx in var.required_status_check_contexts : {
+            context        = ctx
+            integration_id = 0
+          }
+        ]
+      }
+    }
+
+    dynamic "required_code_scanning" {
+      for_each = length(var.required_code_scanning_tools) > 0 ? [1] : []
+      content {
+        dynamic "required_code_scanning_tool" {
+          for_each = var.required_code_scanning_tools
+          content {
+            alerts_threshold          = required_code_scanning_tool.value.alerts_threshold
+            security_alerts_threshold = required_code_scanning_tool.value.security_alerts_threshold
+            tool                      = required_code_scanning_tool.value.tool
+          }
+        }
+      }
+    }
+  }
+
+  lifecycle {
+    prevent_destroy = var.prevent_destroy
+  }
+}
+
+resource "github_repository_ruleset" "push_restrictions" {
+  count = var.enable_enhanced_rulesets && (length(var.file_path_restrictions) > 0 || length(var.restricted_file_extensions) > 0) ? 1 : 0
+
+  name        = "${var.name}-push-rules"
+  repository  = github_repository.this.name
+  target      = "push"
+  enforcement = "active"
+
+  dynamic "bypass_actors" {
+    for_each = local.rule_bypass_actors
+    content {
+      actor_id    = bypass_actors.value.actor_id
+      actor_type  = bypass_actors.value.actor_type
+      bypass_mode = bypass_actors.value.bypass_mode
+    }
+  }
+
+  rules {
+    dynamic "file_path_restriction" {
+      for_each = length(var.file_path_restrictions) > 0 ? [1] : []
+      content {
+        restricted_file_paths = var.file_path_restrictions
+      }
+    }
+
+    dynamic "file_extension_restriction" {
+      for_each = length(var.restricted_file_extensions) > 0 ? [1] : []
+      content {
+        restricted_file_extensions = var.restricted_file_extensions
+      }
+    }
+
+    max_file_size {
+      max_file_size = var.max_file_size_mb
+    }
+  }
+
+  lifecycle {
+    prevent_destroy = var.prevent_destroy
+  }
+}

--- a/modules/github-repository/variable.tf
+++ b/modules/github-repository/variable.tf
@@ -1,0 +1,405 @@
+variable "name" {
+  type        = string
+  description = "Repository name"
+
+  validation {
+    condition     = can(regex("^[a-zA-Z0-9._-]+$", var.name))
+    error_message = "Repository name must contain only alphanumeric characters, hyphens, underscores, and dots."
+  }
+}
+
+variable "description" {
+  type        = string
+  description = "Repository description"
+  default     = ""
+}
+
+variable "homepage_url" {
+  type        = string
+  description = "Repository homepage URL"
+  default     = ""
+}
+
+variable "visibility" {
+  type        = string
+  description = "Repository visibility: public, private, or internal"
+  default     = "private"
+
+  validation {
+    condition     = contains(["public", "private", "internal"], var.visibility)
+    error_message = "Visibility must be one of: public, private, internal."
+  }
+}
+
+variable "topics" {
+  type        = list(string)
+  description = "Repository topics (tags)"
+  default     = []
+}
+
+variable "has_issues" {
+  type        = bool
+  description = "Enable GitHub Issues"
+  default     = true
+}
+
+variable "has_discussions" {
+  type        = bool
+  description = "Enable GitHub Discussions"
+  default     = false
+}
+
+variable "has_projects" {
+  type        = bool
+  description = "Enable GitHub Projects"
+  default     = false
+}
+
+variable "has_wiki" {
+  type        = bool
+  description = "Enable Wiki"
+  default     = false
+}
+
+variable "is_template" {
+  type        = bool
+  description = "Mark as template repository"
+  default     = false
+}
+
+variable "allow_merge_commit" {
+  type        = bool
+  description = "Allow merge commits"
+  default     = false
+}
+
+variable "allow_squash_merge" {
+  type        = bool
+  description = "Allow squash merges"
+  default     = true
+}
+
+variable "allow_rebase_merge" {
+  type        = bool
+  description = "Allow rebase merges"
+  default     = false
+}
+
+variable "allow_auto_merge" {
+  type        = bool
+  description = "Allow auto-merge of PRs"
+  default     = false
+}
+
+variable "allow_update_branch" {
+  type        = bool
+  description = "Suggest updating PR branches"
+  default     = true
+}
+
+variable "delete_branch_on_merge" {
+  type        = bool
+  description = "Auto-delete head branch after merge"
+  default     = true
+}
+
+variable "web_commit_signoff_required" {
+  type        = bool
+  description = "Require sign-off on web commits"
+  default     = true
+}
+
+variable "squash_merge_commit_title" {
+  type        = string
+  description = "Squash merge commit title: PR_TITLE or COMMIT_OR_PR_TITLE"
+  default     = "PR_TITLE"
+
+  validation {
+    condition     = contains(["PR_TITLE", "COMMIT_OR_PR_TITLE"], var.squash_merge_commit_title)
+    error_message = "squash_merge_commit_title must be PR_TITLE or COMMIT_OR_PR_TITLE."
+  }
+}
+
+variable "squash_merge_commit_message" {
+  type        = string
+  description = "Squash merge commit message: PR_BODY, COMMIT_MESSAGES, or BLANK"
+  default     = "PR_BODY"
+
+  validation {
+    condition     = contains(["PR_BODY", "COMMIT_MESSAGES", "BLANK"], var.squash_merge_commit_message)
+    error_message = "squash_merge_commit_message must be PR_BODY, COMMIT_MESSAGES, or BLANK."
+  }
+}
+
+variable "auto_init" {
+  type        = bool
+  description = "Create initial commit with empty README"
+  default     = true
+}
+
+variable "gitignore_template" {
+  type        = string
+  description = "Gitignore template name (e.g., Go, Node, Python)"
+  default     = ""
+}
+
+variable "license_template" {
+  type        = string
+  description = "License template (e.g., mit, agpl-3.0, mpl-2.0)"
+  default     = ""
+}
+
+variable "archive_on_destroy" {
+  type        = bool
+  description = "Archive repository on destroy instead of deleting"
+  default     = true
+}
+
+variable "prevent_destroy" {
+  type        = bool
+  description = "Prevent accidental destruction of the repository and all associated resources (branch protection, rulesets). Destroy operations will fail with an error."
+  default     = true
+}
+
+variable "vulnerability_alerts" {
+  type        = bool
+  description = "Enable Dependabot vulnerability alerts"
+  default     = true
+}
+
+variable "enable_advanced_security" {
+  type        = bool
+  description = "Enable GitHub Advanced Security (code scanning, secret scanning). Always on for public repos."
+  default     = true
+}
+
+variable "enable_secret_scanning_push_protection" {
+  type        = bool
+  description = "Enable secret scanning push protection"
+  default     = true
+}
+
+variable "default_branch" {
+  type        = string
+  description = "Default branch name"
+  default     = "main"
+}
+
+variable "protect_default_branch" {
+  type        = bool
+  description = "Enable branch protection on the default branch"
+  default     = true
+}
+
+variable "required_approving_review_count" {
+  type        = number
+  description = "Number of approving reviews required (0-6)"
+  default     = 1
+
+  validation {
+    condition     = var.required_approving_review_count >= 0 && var.required_approving_review_count <= 6
+    error_message = "required_approving_review_count must be between 0 and 6."
+  }
+}
+
+variable "dismiss_stale_reviews" {
+  type        = bool
+  description = "Dismiss stale reviews on new commits"
+  default     = true
+}
+
+variable "require_code_owner_reviews" {
+  type        = bool
+  description = "Require code owner review"
+  default     = false
+}
+
+variable "require_last_push_approval" {
+  type        = bool
+  description = "Require last push approval by someone other than the pusher"
+  default     = true
+}
+
+variable "enforce_admins" {
+  type        = bool
+  description = "Enforce branch protection rules for admins"
+  default     = true
+}
+
+variable "require_signed_commits" {
+  type        = bool
+  description = "Require GPG-signed commits on protected branches"
+  default     = true
+}
+
+variable "require_linear_history" {
+  type        = bool
+  description = "Enforce linear commit history (no merge commits)"
+  default     = true
+}
+
+variable "require_conversation_resolution" {
+  type        = bool
+  description = "Require all PR conversations resolved before merge"
+  default     = true
+}
+
+variable "allows_force_pushes" {
+  type        = bool
+  description = "Allow force pushes"
+  default     = false
+}
+
+variable "allows_deletions" {
+  type        = bool
+  description = "Allow branch deletion"
+  default     = false
+}
+
+variable "lock_branch" {
+  type        = bool
+  description = "Make branch read-only"
+  default     = false
+}
+
+variable "force_push_bypassers" {
+  type        = list(string)
+  description = "Actor IDs allowed to bypass force push restrictions (user or team node IDs)"
+  default     = []
+}
+
+variable "push_allowances" {
+  type        = list(string)
+  description = "Actor IDs allowed to push to protected branch (user or team node IDs)"
+  default     = []
+}
+
+variable "required_status_check_contexts" {
+  type        = list(string)
+  description = "List of required status check contexts"
+  default     = []
+}
+
+variable "required_status_checks_strict" {
+  type        = bool
+  description = "Require branches to be up-to-date before merge"
+  default     = true
+}
+
+variable "required_deployment_environments" {
+  type        = list(string)
+  description = "List of required deployment environments"
+  default     = []
+}
+
+variable "dismissal_restrictions" {
+  type        = list(string)
+  description = "Actor IDs with review dismissal access"
+  default     = []
+}
+
+variable "restrict_dismissals" {
+  type        = bool
+  description = "Restrict who can dismiss reviews"
+  default     = true
+}
+
+variable "additional_branch_protections" {
+  type = list(object({
+    pattern                       = string
+    enforce_admins                = optional(bool, true)
+    require_signed_commits        = optional(bool, true)
+    required_linear_history       = optional(bool, true)
+    require_conversation_resolution = optional(bool, true)
+    allows_force_pushes           = optional(bool, false)
+    allows_deletions              = optional(bool, false)
+    lock_branch                   = optional(bool, false)
+    required_approving_review_count = optional(number, 1)
+    dismiss_stale_reviews         = optional(bool, true)
+    require_code_owner_reviews    = optional(bool, false)
+    require_last_push_approval    = optional(bool, true)
+    restrict_dismissals           = optional(bool, true)
+    force_push_bypassers          = optional(list(string), [])
+    push_allowances               = optional(list(string), [])
+    required_status_check_contexts = optional(list(string), [])
+    required_status_checks_strict = optional(bool, true)
+    dismissal_restrictions        = optional(list(string), [])
+    required_deployment_environments = optional(list(string), [])
+  }))
+  description = "Additional branch protection rules for non-default branches"
+  default     = []
+}
+
+variable "pages" {
+  type = object({
+    build_type = optional(string, "workflow")
+    cname      = optional(string, "")
+    source = optional(object({
+      branch = string
+      path   = optional(string, "/")
+    }), null)
+  })
+  description = "GitHub Pages configuration"
+  default     = null
+}
+
+variable "template" {
+  type = object({
+    owner                = string
+    repository           = string
+    include_all_branches = optional(bool, false)
+  })
+  description = "Template repository to use for initialization"
+  default     = null
+}
+
+# ── Enhanced Repository Rulesets ──────────────────────────────────
+
+variable "enable_enhanced_rulesets" {
+  type        = bool
+  description = "Enable repository rulesets in addition to branch protection (for file path restrictions, required code scanning, etc.)"
+  default     = false
+}
+
+variable "ruleset_bypass_actors" {
+  type = list(object({
+    actor_id    = string
+    actor_type  = string
+    bypass_mode = string
+  }))
+  description = "Actors that can bypass repository rulesets. actor_type: Integration, Team, RepositoryRole, OrganizationAdmin. bypass_mode: always, pull_request."
+  default     = []
+}
+
+variable "required_code_scanning_tools" {
+  type = list(object({
+    alerts_threshold          = string
+    security_alerts_threshold = string
+    tool                      = string
+  }))
+  description = "Required code scanning tools (e.g., CodeQL with alert thresholds)"
+  default     = []
+}
+
+variable "file_path_restrictions" {
+  type        = list(string)
+  description = "Restricted file paths in push ruleset"
+  default     = []
+}
+
+variable "restricted_file_extensions" {
+  type        = list(string)
+  description = "Blocked file extensions in push ruleset"
+  default     = [".exe", ".dll", ".so", ".dylib"]
+}
+
+variable "max_file_size_mb" {
+  type        = number
+  description = "Maximum file size in MB (push ruleset, 1-100)"
+  default     = 100
+
+  validation {
+    condition     = var.max_file_size_mb >= 1 && var.max_file_size_mb <= 100
+    error_message = "max_file_size_mb must be between 1 and 100."
+  }
+}

--- a/modules/github-repository/version.tf
+++ b/modules/github-repository/version.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = "~> 1.8"
+
+  required_providers {
+    github = {
+      source  = "integrations/github"
+      version = "~> 6.6"
+    }
+  }
+}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #1589
* __->__ #1588

Add OpenTofu module for provisioning GitHub repositories with
security-hardened defaults: private visibility, signed commits,
linear history, required reviews, GHAS enabled, secret scanning
push protection, archive-on-destroy, and prevent_destroy lifecycle
on all resources. Includes optional enhanced repository rulesets
for file path restrictions and required code scanning.

Design: Module follows existing longhorn module conventions
(version.tf, variable.tf, outputs.tf, logic-split .tf files).
Provider: integrations/github ~> 6.6.

Includes example bootstrap for shikanime/shikanime public repo.