### PR TITLE
Enable kubeProxy and kubeDns monitoring integrations for VictoriaMetrics

### DIFF
--- a/infrastructure/monitoring/base/hr.yaml
+++ b/infrastructure/monitoring/base/hr.yaml
@@ -33,3 +33,7 @@ spec:
             requests:
               storage: 8Gi
       enabled: true
+    kubeProxy:
+      enabled: true
+    kubeDns:
+      enabled: true


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #1591

