### PR TITLE
Fix duplicate monitoring component in longhorn tailnet overlays

### DIFF
--- a/infrastructure/longhorn/overlays/nishir-tailnet/kustomization.yaml
+++ b/infrastructure/longhorn/overlays/nishir-tailnet/kustomization.yaml
@@ -1,6 +1,4 @@
 resources:
   - ../nishir
-components:
-  - ../../components/monitoring
 patches:
   - path: patch-hr.yaml

--- a/infrastructure/longhorn/overlays/talashi-tailnet/kustomization.yaml
+++ b/infrastructure/longhorn/overlays/talashi-tailnet/kustomization.yaml
@@ -1,7 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 resources:
-  - ../../base
   - ../talashi
-components:
-  - ../../components/monitoring
 patches:
   - path: patch-hr.yaml

--- a/infrastructure/longhorn/overlays/talashi-tailnet/kustomization.yaml
+++ b/infrastructure/longhorn/overlays/talashi-tailnet/kustomization.yaml
@@ -1,5 +1,3 @@
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
 resources:
   - ../talashi
 patches:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* __->__ #1597

nishir-tailnet and talashi-tailnet both referenced ../nishir (or ../talashi)
as a resource — which already includes ../../components/monitoring — and then
added the same component again, causing kustomize to fail with 'may not add
resource with an already registered id: VMServiceScrape/.../longhorn-manager'.

Remove the redundant components: [../../components/monitoring] from both
overlays. Also restore apiVersion/kind headers in talashi-tailnet.