### PR TITLE
Fix missing cert-manager-system

### DIFF
--- a/infrastructure/cert-manager/base/ns.yaml
+++ b/infrastructure/cert-manager/base/ns.yaml
@@ -1,4 +1,10 @@
+---
 apiVersion: v1
 kind: Namespace
 metadata:
   name: cert-manager-trust
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cert-manager-system


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* __->__ #1607
* #1606

Signed-off-by: Shikanime Deva <william.phetsinorath@shikanime.studio>
Change-Id: Ide6340fa65e66714829bf0dbf08b05316a6a6964