### PR TITLE
Fix Cluster API config missing dependsOn

### DIFF
--- a/infrastructure/cluster-api/overlays/telsha/ks.yaml
+++ b/infrastructure/cluster-api/overlays/telsha/ks.yaml
@@ -9,6 +9,8 @@ spec:
     secretRef:
       name: sops-age
   deletionPolicy: Orphan
+  dependsOn:
+    - name: infrastructure-cluster-api
   interval: 10m
   path: ./configs/cluster-api/overlays/telsha
   prune: true


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* #1614
* __->__ #1613

Signed-off-by: Shikanime Deva <william.phetsinorath@shikanime.studio>
Change-Id: I742c23d51dfa4377dd6a6766743cc0266a6a6964