### PR TITLE
Fix Cluster API missing CoreProvider

### DIFF
--- a/infrastructure/cluster-api/base/hr.yaml
+++ b/infrastructure/cluster-api/base/hr.yaml
@@ -12,7 +12,6 @@ spec:
       sourceRef:
         name: cluster-api-operator
         kind: HelmRepository
-        namespace: flux-system
   install:
     crds: Create
   interval: 10m
@@ -27,6 +26,7 @@ spec:
       enabled: true
     controlPlane:
       k0sproject-k0smotron: {}
+    enableHelmHook: false
     infrastructure:
       hetzner: {}
       k0sproject-k0smotron: {}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* __->__ #1615

Signed-off-by: Shikanime Deva <william.phetsinorath@shikanime.studio>
Change-Id: Ied652b8a04acfa90d98b84e462c95fd36a6a6964