### PR TITLE
Add Syncthing canary overlay with Gateway API resources

### DIFF
--- a/apps/syncthing/overlays/nishir-gateway/httproute-ui.yaml
+++ b/apps/syncthing/overlays/nishir-gateway/httproute-ui.yaml
@@ -1,0 +1,14 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: syncthing-ui
+spec:
+  parentRefs:
+    - name: traefik-gateway
+      namespace: kube-system
+  hostnames:
+    - syncthing.taila659a.ts.net
+  rules:
+    - backendRefs:
+        - name: syncthing
+          port: 80

--- a/apps/syncthing/overlays/nishir-gateway/kustomization.yaml
+++ b/apps/syncthing/overlays/nishir-gateway/kustomization.yaml
@@ -1,0 +1,9 @@
+resources:
+  - ../nishir
+  - httproute-ui.yaml
+  - tcproute-replication.yaml
+namespace: shikanime
+labels:
+  - includeTemplates: true
+    pairs:
+      app.kubernetes.io/canary: syncthing-gateway-api

--- a/apps/syncthing/overlays/nishir-gateway/tcproute-replication.yaml
+++ b/apps/syncthing/overlays/nishir-gateway/tcproute-replication.yaml
@@ -1,0 +1,12 @@
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: TCPRoute
+metadata:
+  name: syncthing-replication
+spec:
+  parentRefs:
+    - name: traefik-gateway
+      namespace: kube-system
+  rules:
+    - backendRefs:
+        - name: syncthing-replication
+          port: 22000

--- a/infrastructure/traefik-gateway/base/gateway.yaml
+++ b/infrastructure/traefik-gateway/base/gateway.yaml
@@ -1,0 +1,25 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: traefik-gateway
+  namespace: kube-system
+spec:
+  gatewayClassName: traefik
+  listeners:
+    - name: web
+      protocol: HTTP
+      port: 80
+      allowedRoutes:
+        namespaces:
+          from: All
+    - name: websecure
+      protocol: HTTPS
+      port: 443
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - kind: Secret
+            name: traefik-tls
+      allowedRoutes:
+        namespaces:
+          from: All

--- a/infrastructure/traefik-gateway/base/kustomization.yaml
+++ b/infrastructure/traefik-gateway/base/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - gateway.yaml


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #1627
* #1626
* #1625
* __->__ #1624

Add HTTPRoute for Syncthing UI (syncthing.taila659a.ts.net) and TCPRoute
for Syncthing replication (port 22000) via Traefik Gateway API. Also add
infrastructure/traefik-gateway base component with Gateway resource in
kube-system namespace.

Design:
- Gateway: traefik-gateway in kube-system, gatewayClassName: traefik
- Listeners: web (80/HTTP), websecure (443/HTTPS with TLS terminate)
- HTTPRoute: syncthing-ui → syncthing:80
- TCPRoute: syncthing-replication → syncthing-replication:22000
- Canary overlay: nishir-gateway (coexists with nishir-tailnet)