### PR TITLE
Remove websecure listener from nishir Gateway

### DIFF
--- a/clusters/nishir/base/gateway.yaml
+++ b/clusters/nishir/base/gateway.yaml
@@ -12,14 +12,6 @@ spec:
       allowedRoutes:
         namespaces:
           from: All
-    - name: websecure
-      port: 443
-      protocol: HTTPS
-      tls:
-        mode: Terminate
-      allowedRoutes:
-        namespaces:
-          from: All
     - name: tcp
       port: 22000
       protocol: TCP


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #1636

The websecure listener used mode: Terminate without certificateRefs,
which caused a validation error on the API server. Traefik handles
TLS termination internally; the Gateway only needs web (HTTP/80) and
tcp (TCP/22000) listeners.