### PR TITLE
Move nishir Gateway to shikanime namespace with Same-namespace routes

### DIFF
--- a/apps/syncthing/base/httproute.yaml
+++ b/apps/syncthing/base/httproute.yaml
@@ -7,7 +7,6 @@ spec:
     - syncthing.taila659a.ts.net
   parentRefs:
     - name: nishir
-      namespace: kube-system
   rules:
     - backendRefs:
         - name: syncthing

--- a/apps/syncthing/base/tcproute.yaml
+++ b/apps/syncthing/base/tcproute.yaml
@@ -5,7 +5,6 @@ metadata:
 spec:
   parentRefs:
     - name: nishir
-      namespace: kube-system
   rules:
     - backendRefs:
         - name: syncthing

--- a/apps/syncthing/base/udproute.yaml
+++ b/apps/syncthing/base/udproute.yaml
@@ -5,7 +5,6 @@ metadata:
 spec:
   parentRefs:
     - name: nishir
-      namespace: kube-system
   rules:
     - backendRefs:
         - name: syncthing

--- a/clusters/nishir/base/gateway.yaml
+++ b/clusters/nishir/base/gateway.yaml
@@ -2,7 +2,6 @@ apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
   name: nishir
-  namespace: kube-system
 spec:
   gatewayClassName: traefik
   listeners:
@@ -11,18 +10,10 @@ spec:
       protocol: HTTP
       allowedRoutes:
         namespaces:
-          from: All
-    - name: websecure
-      port: 443
-      protocol: HTTPS
-      tls:
-        mode: Terminate
-      allowedRoutes:
-        namespaces:
-          from: All
+          from: Same
     - name: tcp
       port: 22000
       protocol: TCP
       allowedRoutes:
         namespaces:
-          from: All
+          from: Same


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #1637

