### PR TITLE
Fix Gateway websecure listener and switch to TLSRoute

### DIFF
--- a/apps/syncthing/base/httproute.yaml
+++ b/apps/syncthing/base/httproute.yaml
@@ -14,11 +14,13 @@ spec:
         - name: syncthing
           port: 8384
 ---
-apiVersion: gateway.networking.k8s.io/v1
-kind: HTTPRoute
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: TLSRoute
 metadata:
   name: syncthing-https
 spec:
+  hostnames:
+    - syncthing.taila659a.ts.net
   parentRefs:
     - name: nishir
       sectionName: websecure

--- a/apps/syncthing/overlays/nishir/kustomization.yaml
+++ b/apps/syncthing/overlays/nishir/kustomization.yaml
@@ -5,6 +5,5 @@ namespace: shikanime
 components:
   - ../../components/tls
 patches:
-  - path: patch-httproute.yaml
   - path: patch-pvc.yaml
   - path: patch-sts.yaml

--- a/clusters/nishir/base/gateway.yaml
+++ b/clusters/nishir/base/gateway.yaml
@@ -14,7 +14,7 @@ spec:
           from: Same
     - name: websecure
       port: 443
-      protocol: HTTPS
+      protocol: TLS
       tls:
         mode: Passthrough
       allowedRoutes:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #1643
* __->__ #1642

Change websecure listener from protocol HTTPS to TLS with mode
Passthrough, as Passthrough is not valid for HTTPS listeners in the
Gateway API spec. Convert the syncthing-https HTTPRoute to a TLSRoute
to match the TLS listener protocol. Remove the now-obsolete
patch-httproute.yaml from the overlay.