### PR TITLE
Add back nishir certificate for Flux SSA reconciliation

### DIFF
--- a/clusters/nishir/base/cert.yaml
+++ b/clusters/nishir/base/cert.yaml
@@ -1,0 +1,17 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: nishir
+  namespace: shikanime
+spec:
+  commonName: nishir
+  dnsNames:
+    - syncthing.taila659a.ts.net
+  issuerRef:
+    name: nishir
+    kind: ClusterIssuer
+  secretName: nishir-tls
+  usages:
+    - digital signature
+    - key encipherment
+    - server auth

--- a/clusters/nishir/base/kustomization.yaml
+++ b/clusters/nishir/base/kustomization.yaml
@@ -1,5 +1,6 @@
 resources:
   - alert.yaml
+  - cert.yaml
   - gateway.yaml
   - ingress.yaml
   - netpol.yaml


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #1643
* #1642

