### PR TITLE
Fix cert missing namespace

### DIFF
--- a/clusters/nishir/base/cert.yaml
+++ b/clusters/nishir/base/cert.yaml
@@ -2,6 +2,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: nishir
+  namespace: shikanime
 spec:
   commonName: nishir
   dnsNames:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* __->__ #1644

Signed-off-by: Shikanime Deva <william.phetsinorath@shikanime.studio>
Change-Id: I18a98fe55bf69653046f5b94fb8b9a636a6a6964