### PR TITLE
Fix syncthing Gateway Timeout with BackendTLSPolicy

### DIFF
--- a/apps/syncthing/overlays/nishir/backendtlspolicy.yaml
+++ b/apps/syncthing/overlays/nishir/backendtlspolicy.yaml
@@ -1,0 +1,16 @@
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: BackendTLSPolicy
+metadata:
+  name: syncthing
+spec:
+  targetRefs:
+    - group: ""
+      kind: Service
+      name: syncthing
+  validation:
+    caCertificateRefs:
+      - group: ""
+        kind: Secret
+        name: nishir-ca
+        namespace: cert-manager-trust
+    hostname: syncthing.taila659a.ts.net

--- a/apps/syncthing/overlays/nishir/cert.yaml
+++ b/apps/syncthing/overlays/nishir/cert.yaml
@@ -6,6 +6,7 @@ spec:
   commonName: syncthing
   dnsNames:
     - syncthing
+    - syncthing.taila659a.ts.net
   issuerRef:
     name: nishir
     kind: ClusterIssuer

--- a/apps/syncthing/overlays/nishir/kustomization.yaml
+++ b/apps/syncthing/overlays/nishir/kustomization.yaml
@@ -1,5 +1,6 @@
 resources:
   - ../../base
+  - backendtlspolicy.yaml
   - cert.yaml
 namespace: shikanime
 components:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* __->__ #1646

Traefik terminates TLS at the websecure listener but forwards plain
HTTP to the syncthing backend which speaks HTTPS natively. Configure
a BackendTLSPolicy so Traefik re-encrypts with CA verification
against the nishir CA, and add the syncthing FQDN as a SAN to the
certificate so hostname validation succeeds.

Signed-off-by: Shikanime Deva <william.phetsinorath@shikanime.studio>