### PR TITLE
Fix BackendTLSPolicy cross-namespace CA reference

### DIFF
--- a/apps/syncthing/overlays/nishir/backendtlspolicy.yaml
+++ b/apps/syncthing/overlays/nishir/backendtlspolicy.yaml
@@ -1,4 +1,4 @@
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1
 kind: BackendTLSPolicy
 metadata:
   name: syncthing
@@ -10,7 +10,6 @@ spec:
   validation:
     caCertificateRefs:
       - group: ""
-        kind: Secret
-        name: nishir-ca
-        namespace: cert-manager-trust
+        kind: ConfigMap
+        name: nishir-ca-certificates.crt
     hostname: syncthing.taila659a.ts.net

--- a/configs/cert-manager/overlays/nishir/bundle.yaml
+++ b/configs/cert-manager/overlays/nishir/bundle.yaml
@@ -6,8 +6,8 @@ spec:
   sources:
     - secret:
         name: nishir-ca
-        key: tls.crt
+        key: ca.crt
     - useDefaultCAs: true
   target:
     configMap:
-      key: ca-certificates.crt
+      key: ca.crt


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* __->__ #1647

The v1 BackendTLSPolicy CRD does not support namespace on
caCertificateRefs. Switch from a cross-namespace Secret reference
to a same-namespace ConfigMap reference.

Also fix the trust-manager Bundle to populate the target ConfigMap
with the CA cert (key: ca.crt) instead of the leaf cert (tls.crt).

Signed-off-by: Shikanime Deva <william.phetsinorath@shikanime.studio>