### PR TITLE
Update Gatekeeper CA path for renamed ConfigMap key

### DIFF
--- a/configs/gatekeeper/overlays/nishir/mutations.yaml
+++ b/configs/gatekeeper/overlays/nishir/mutations.yaml
@@ -123,7 +123,7 @@ spec:
     values:
       fromList:
         - name: NODE_EXTRA_CA_CERTS
-          value: /etc/ssl/certs/ca-certificates.crt
+          value: /etc/ssl/certs/ca.crt
 ---
 apiVersion: mutations.gatekeeper.sh/v1
 kind: ModifySet
@@ -162,4 +162,4 @@ spec:
     values:
       fromList:
         - name: NODE_EXTRA_CA_CERTS
-          value: /etc/ssl/certs/ca-certificates.crt
+          value: /etc/ssl/certs/ca.crt


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* __->__ #1648

The trust-manager Bundle now uses ca.crt as the ConfigMap target key
instead of ca-certificates.crt. Update the NODE_EXTRA_CA_CERTS env var
in Gatekeeper mutations to point to the new file path.

Signed-off-by: Shikanime Deva <william.phetsinorath@shikanime.studio>