### PR TITLE
Use ServersTransport with syncthing-tls CA for backend TLS

### DIFF
--- a/apps/syncthing/overlays/nishir/backendtlspolicy.yaml
+++ b/apps/syncthing/overlays/nishir/backendtlspolicy.yaml
@@ -4,12 +4,12 @@ metadata:
   name: syncthing
 spec:
   targetRefs:
-    - group: ""
+    - name: syncthing
+      group: ""
       kind: Service
-      name: syncthing
   validation:
     caCertificateRefs:
-      - group: ""
+      - name: syncthing-tls
+        group: ""
         kind: Secret
-        name: syncthing-tls
     hostname: syncthing.taila659a.ts.net

--- a/apps/syncthing/overlays/nishir/kustomization.yaml
+++ b/apps/syncthing/overlays/nishir/kustomization.yaml
@@ -1,7 +1,7 @@
 resources:
   - ../../base
-  - backendtlspolicy.yaml
   - cert.yaml
+  - serverstransport.yaml
 namespace: shikanime
 components:
   - ../../components/tls

--- a/apps/syncthing/overlays/nishir/patch-httproute.yaml
+++ b/apps/syncthing/overlays/nishir/patch-httproute.yaml
@@ -2,6 +2,8 @@ apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: syncthing-https
+  annotations:
+    traefik.ingress.kubernetes.io/service.serverstransport: shikanime-syncthing@kubernetescrd
 spec:
   hostnames:
     - syncthing.taila659a.ts.net

--- a/apps/syncthing/overlays/nishir/serverstransport.yaml
+++ b/apps/syncthing/overlays/nishir/serverstransport.yaml
@@ -1,0 +1,8 @@
+apiVersion: traefik.io/v1alpha1
+kind: ServersTransport
+metadata:
+  name: syncthing
+spec:
+  rootCAs:
+    - secret: syncthing-tls
+  serverName: syncthing


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* __->__ #1649

Traefik v3.6 does not support Secret refs in BackendTLSPolicy.
Switch to a Traefik ServersTransport that reads the CA cert from
the syncthing-tls Secret (which cert-manager populates with the
signing CA). Reference it from the HTTPRoute via annotation.

Signed-off-by: Shikanime Deva <william.phetsinorath@shikanime.studio>