### PR TITLE
Add insecureSkipVerify to syncthing ServersTransport

### DIFF
--- a/apps/syncthing/overlays/nishir/serverstransport.yaml
+++ b/apps/syncthing/overlays/nishir/serverstransport.yaml
@@ -3,6 +3,4 @@ kind: ServersTransport
 metadata:
   name: syncthing
 spec:
-  rootCAs:
-    - secret: syncthing-tls
-  serverName: syncthing
+  insecureSkipVerify: true


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* __->__ #1650

The syncthing backend cert has no IP SANs, so Traefik cannot validate
the certificate when connecting to the pod IP. Skip verification
since the backend uses a self-signed cert.

Signed-off-by: Shikanime Deva <william.phetsinorath@shikanime.studio>