### PR TITLE
Use BackendTLSPolicy with ConfigMap, rename Bundle key to ca.crt

### DIFF
--- a/apps/syncthing/overlays/nishir/backendtlspolicy.yaml
+++ b/apps/syncthing/overlays/nishir/backendtlspolicy.yaml
@@ -9,7 +9,7 @@ spec:
       kind: Service
   validation:
     caCertificateRefs:
-      - name: syncthing-tls
-        group: ""
-        kind: Secret
+      - group: ""
+        kind: ConfigMap
+        name: nishir-ca-certificates.crt
     hostname: syncthing.taila659a.ts.net

--- a/apps/syncthing/overlays/nishir/kustomization.yaml
+++ b/apps/syncthing/overlays/nishir/kustomization.yaml
@@ -1,7 +1,7 @@
 resources:
   - ../../base
+  - backendtlspolicy.yaml
   - cert.yaml
-  - serverstransport.yaml
 namespace: shikanime
 components:
   - ../../components/tls

--- a/apps/syncthing/overlays/nishir/patch-httproute.yaml
+++ b/apps/syncthing/overlays/nishir/patch-httproute.yaml
@@ -2,8 +2,6 @@ apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: syncthing-https
-  annotations:
-    traefik.ingress.kubernetes.io/service.serverstransport: shikanime-syncthing@kubernetescrd
 spec:
   hostnames:
     - syncthing.taila659a.ts.net

--- a/apps/syncthing/overlays/nishir/serverstransport.yaml
+++ b/apps/syncthing/overlays/nishir/serverstransport.yaml
@@ -1,6 +1,0 @@
-apiVersion: traefik.io/v1alpha1
-kind: ServersTransport
-metadata:
-  name: syncthing
-spec:
-  insecureSkipVerify: true

--- a/configs/cert-manager/overlays/nishir/bundle.yaml
+++ b/configs/cert-manager/overlays/nishir/bundle.yaml
@@ -10,4 +10,4 @@ spec:
     - useDefaultCAs: true
   target:
     configMap:
-      key: ca-certificates.crt
+      key: ca.crt

--- a/configs/gatekeeper/overlays/nishir/mutations.yaml
+++ b/configs/gatekeeper/overlays/nishir/mutations.yaml
@@ -27,6 +27,9 @@ spec:
         name: certs
         configMap:
           name: nishir-ca-certificates.crt
+          items:
+            - key: ca.crt
+              path: ca-certificates.crt
 ---
 apiVersion: mutations.gatekeeper.sh/v1
 kind: Assign


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* __->__ #1651

Switch from ServersTransport to BackendTLSPolicy for proper backend
TLS validation. Requires renaming the trust-manager Bundle target key
from ca-certificates.crt to ca.crt (Gateway API spec requirement).

Update Gatekeeper volume mutation to map ca.crt key to
ca-certificates.crt file path so NODE_EXTRA_CA_CERTS remains valid.

Signed-off-by: Shikanime Deva <william.phetsinorath@shikanime.studio>