### PR TITLE
Consolidate syncthing HTTPRoute to single HTTPS endpoint

### DIFF
--- a/apps/syncthing/base/httproute.yaml
+++ b/apps/syncthing/base/httproute.yaml
@@ -1,21 +1,7 @@
----
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: syncthing
-spec:
-  parentRefs:
-    - name: nishir
-      sectionName: web
-  rules:
-    - backendRefs:
-        - name: syncthing
-          port: 8384
----
-apiVersion: gateway.networking.k8s.io/v1
-kind: HTTPRoute
-metadata:
-  name: syncthing-https
 spec:
   parentRefs:
     - name: nishir

--- a/apps/syncthing/overlays/nishir/patch-httproute.yaml
+++ b/apps/syncthing/overlays/nishir/patch-httproute.yaml
@@ -1,7 +1,7 @@
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
-  name: syncthing-https
+  name: syncthing
 spec:
   hostnames:
     - syncthing.taila659a.ts.net


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* __->__ #1652

Remove the plain HTTP route (web listener) and rename the HTTPS
route to syncthing. The single route attaches to the websecure
listener with the tailscale hostname.

Signed-off-by: Shikanime Deva <william.phetsinorath@shikanime.studio>