### PR TITLE
Add sectionName to syncthing TCPRoute

### DIFF
--- a/apps/syncthing/base/tcproute.yaml
+++ b/apps/syncthing/base/tcproute.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   parentRefs:
     - name: nishir
+      sectionName: tcp
   rules:
     - backendRefs:
         - name: syncthing


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* __->__ #1653

Explicitly set sectionName: tcp on the parentRef for clarity.

Signed-off-by: Shikanime Deva <william.phetsinorath@shikanime.studio>