### PR TITLE
Make web listener use HTTPS, attach HTTPRoute to both listeners

### DIFF
--- a/apps/syncthing/overlays/nishir/patch-httproute.yaml
+++ b/apps/syncthing/overlays/nishir/patch-httproute.yaml
@@ -5,3 +5,8 @@ metadata:
 spec:
   hostnames:
     - syncthing.taila659a.ts.net
+  parentRefs:
+    - name: nishir
+      sectionName: web
+    - name: nishir
+      sectionName: websecure

--- a/clusters/nishir/base/gateway.yaml
+++ b/clusters/nishir/base/gateway.yaml
@@ -8,22 +8,28 @@ spec:
   listeners:
     - name: web
       port: 80
-      protocol: HTTP
+      protocol: HTTPS
       allowedRoutes:
         namespaces:
           from: Same
+      tls:
+        certificateRefs:
+          - name: nishir-tls
+            group: ""
+            kind: Secret
+        mode: Terminate
     - name: websecure
       port: 443
       protocol: HTTPS
-      tls:
-        mode: Terminate
-        certificateRefs:
-          - kind: Secret
-            group: ""
-            name: nishir-tls
       allowedRoutes:
         namespaces:
           from: Same
+      tls:
+        certificateRefs:
+          - name: nishir-tls
+            group: ""
+            kind: Secret
+        mode: Terminate
     - name: tcp
       port: 22000
       protocol: TCP


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* __->__ #1654

The web listener (port 80) now terminates TLS using the nishir-tls
certificate, allowing HTTPS on both port 80 and 443. The syncthing
HTTPRoute attaches to both web and websecure listeners.

Signed-off-by: Shikanime Deva <william.phetsinorath@shikanime.studio>