### PR TITLE
Remove downstream Tailscale hostname

### DIFF
--- a/apps/syncthing/overlays/nishir/cert.yaml
+++ b/apps/syncthing/overlays/nishir/cert.yaml
@@ -6,7 +6,6 @@ spec:
   commonName: syncthing
   dnsNames:
     - syncthing
-    - syncthing.taila659a.ts.net
   issuerRef:
     name: nishir
     kind: ClusterIssuer


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* __->__ #1664

Signed-off-by: Shikanime Deva <william.phetsinorath@shikanime.studio>
Change-Id: I64d9468362fa8d3c8416864dd5245be06a6a6964