### PR TITLE
Deploy OpenLDAP and Dex SSO infrastructure

### DIFF
--- a/.sops.yaml
+++ b/.sops.yaml
@@ -1,0 +1,4 @@
+creation_rules:
+  - key_groups:
+      - age:
+          - age139fcg32lmhxupnz5wjex44jur7v7wzf9rttp2grnjmxhukck5dmqsd9zj5

--- a/apps/dex/base/deploy.yaml
+++ b/apps/dex/base/deploy.yaml
@@ -1,0 +1,58 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dex
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: dex
+      app.kubernetes.io/name: dex
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/instance: dex
+        app.kubernetes.io/name: dex
+    spec:
+      containers:
+        - name: dex
+          image: ghcr.io/dexidp/dex:v2.41.1
+          args:
+            - serve
+            - /etc/dex/config.yaml
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          ports:
+            - name: http
+              containerPort: 5556
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 5
+          volumeMounts:
+            - name: config
+              mountPath: /etc/dex
+            - name: data
+              mountPath: /var/dex
+            - name: openldap-ca
+              mountPath: /etc/dex/openldap-ca
+              readOnly: true
+      volumes:
+        - name: config
+          secret:
+            secretName: dex
+        - name: data
+          persistentVolumeClaim:
+            claimName: dex
+        - name: openldap-ca
+          secret:
+            items:
+              - key: tls.crt
+                path: ca.crt
+            secretName: openldap-tls

--- a/apps/dex/base/kustomization.yaml
+++ b/apps/dex/base/kustomization.yaml
@@ -1,0 +1,5 @@
+resources:
+  - deploy.yaml
+  - svc.yaml
+  - pvc.yaml
+  - netpol.yaml

--- a/apps/dex/base/netpol.yaml
+++ b/apps/dex/base/netpol.yaml
@@ -1,0 +1,15 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: dex
+spec:
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: shikanime
+      ports:
+        - port: http
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/instance: dex

--- a/apps/dex/base/pvc.yaml
+++ b/apps/dex/base/pvc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: dex
+spec:
+  resources:
+    requests:
+      storage: 2Gi
+  storageClassName: longhorn
+  accessModes:
+    - ReadWriteOnce

--- a/apps/dex/base/svc.yaml
+++ b/apps/dex/base/svc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: dex
+spec:
+  ports:
+    - name: http
+      port: 5556
+      targetPort: http
+  selector:
+    app.kubernetes.io/instance: dex
+    app.kubernetes.io/name: dex

--- a/apps/dex/overlays/nishir-tailnet/ingress.yaml
+++ b/apps/dex/overlays/nishir-tailnet/ingress.yaml
@@ -1,0 +1,16 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: dex
+  annotations:
+    tailscale.com/tags: tag:web
+spec:
+  defaultBackend:
+    service:
+      name: dex
+      port:
+        name: http
+  ingressClassName: tailscale
+  tls:
+    - hosts:
+        - dex

--- a/apps/dex/overlays/nishir-tailnet/kustomization.yaml
+++ b/apps/dex/overlays/nishir-tailnet/kustomization.yaml
@@ -1,0 +1,5 @@
+resources:
+  - ../nishir
+  - ingress.yaml
+  - netpol.yaml
+namespace: shikanime

--- a/apps/dex/overlays/nishir-tailnet/netpol.yaml
+++ b/apps/dex/overlays/nishir-tailnet/netpol.yaml
@@ -1,0 +1,18 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: dex
+spec:
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: shikanime
+      ports:
+        - port: http
+    - from: []
+      ports:
+        - port: http
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/instance: dex

--- a/apps/dex/overlays/nishir/dex/config.enc.yaml
+++ b/apps/dex/overlays/nishir/dex/config.enc.yaml
@@ -1,0 +1,87 @@
+connectors:
+  - name: ENC[AES256_GCM,data:kcRNBw==,iv:/MH9CkTlSZIrPIBu6YuFVnRXMJKK8CZQ0NXlBuNxmAQ=,tag:t43hUixZln0EL91yoeR2Zg==,type:str]
+    type: ENC[AES256_GCM,data:BFbEow==,iv:ZCDOwqBauNsw7hdfmsQnP7zmWDGb+MDkvpRECF6C6rA=,tag:hNNAu6RJCbMXGBoTLrLn7g==,type:str]
+    id: ENC[AES256_GCM,data:ytEd6w==,iv:L6GJk1PYZpAXOYRfkBiCiGGxONxldXfdUtzYyAHwZpE=,tag:WEjJCpRJjU2TkFLKVxk9LA==,type:str]
+    config:
+      bindDN: ENC[AES256_GCM,data:3m/OzYO6dk5q4MYWL31hS2TkGd61PGxo5s87U/oeJA==,iv:D0M+CNp3uxoqAXx+ATjh6JCX3ySEQhiD//6ZGe9RX/k=,tag:Mru7iNatNcvw8WrHY9GSCQ==,type:str]
+      bindPW: ENC[AES256_GCM,data:NrS1G8vbay/7XCy/QQZQOuraNMFYrXZf2nDVluEWqLjKQwqXW0NdIwyOSw==,iv:Kd9gvrvOBwOQ2nojdHrB35pk9djkfOHe/z3+IlEc4Po=,tag:tkmdL194hFSZKFTk5NSo0g==,type:str]
+      groupSearch:
+        baseDN: ENC[AES256_GCM,data:j1ekcJq8aYY0WB6fpUbjn75MipojYzRMFwE3MFFCCZw=,iv:xYMl2dY2TNrfdelZRWhTQgJICLPYaEAHcl6P7RG+cRo=,tag:y/LZWyT3i9aXQB3D9VcBvg==,type:str]
+        filter: ENC[AES256_GCM,data:gsFRSZVxhzgBk/jARgXwr9gulnnBmCjG/D8=,iv:NVLM7n1o8LqHOKTLsaTUlcNl/595jkJNLWKcS+N1Ggw=,tag:LEM/lsOaPOFpBbClk9LK0Q==,type:str]
+        nameAttr: ENC[AES256_GCM,data:PjY=,iv:iYcw0HGyi2sJTw9vUbUkGD+shuyO5oKh9rTTeAjn4O8=,tag:Z0acnBiV8UgmkPK+cl2yiA==,type:str]
+        userMatchers:
+          - groupAttr: ENC[AES256_GCM,data:mGrf1USV,iv:WArKKN9v8E5kJ7ceaw/osd33mINL/SE/29xAcrhs61Y=,tag:IfkBsFghAevDcwXhQ2gdzg==,type:str]
+            userAttr: ENC[AES256_GCM,data:Cck=,iv:42EhaF2/swbVWnnahnlSWP2f6za1biWqJDJyOYIkPyk=,tag:IoQjDurYRJAQHPA1UrlUNA==,type:str]
+      host: ENC[AES256_GCM,data:x3YeMxITcrggFFIa,iv:YQ9ekN+JJUFmngI2BzXaoAdk0JXme9dAY6lLOxXFaD0=,tag:tQ1NuTBRHRDUUofYyfy6Aw==,type:str]
+      insecureNoSSL: ENC[AES256_GCM,data:hKMO+TM=,iv:xMOoO3YHz8VC9qyhqVeNZotgFHmDSGY/mtS1gKzqffg=,tag:XAGUJFF+vP3i+mPALGpTzQ==,type:bool]
+      insecureSkipVerify: ENC[AES256_GCM,data:SMVGIIQ=,iv:IW66uS/oXkj5Xp1v5Xylb/VznD/LiH3F/wHeozIupNg=,tag:AE0XmJXmRBkJki+x2I/jFg==,type:bool]
+      rootCA: ENC[AES256_GCM,data:CnOscanMnd4plt8cJZivJ1CFLLmopFlIZTxc,iv:IqontKe6M9GA2rDjIUyOeazyjYIhSM62HRUJ6o7KiLg=,tag:UIgMr9fOljz9geYEp55UxQ==,type:str]
+      userSearch:
+        baseDN: ENC[AES256_GCM,data:xF8nSBRJJLJP6bfx13pnkroz5aqM2gVJya9cjmDGhSw=,iv:PAxCfyKpPFglfMUjroKmbOSFCo/fY8WuZqF4fegpMPs=,tag:AmtaNBXW2syL/lpPJ3w94Q==,type:str]
+        emailAttr: ENC[AES256_GCM,data:zoJR+g==,iv:Jvk/iv1XRsQpIMthj+as0b705/+/sYk2qbi75ehZ5Xs=,tag:pMcSPUQRhiyOVHtC8wK8kQ==,type:str]
+        filter: ENC[AES256_GCM,data:VoyqXKEI80jrtfXP4ALOmsEjBEv35dgy+UMZ,iv:y/Ac1vl97ztaNzLQNuhY6WuWvt4iwkWOgImVng9leSA=,tag:OY4spxiq0V9RSsOXlsaJOw==,type:str]
+        idAttr: ENC[AES256_GCM,data:Pn5x/A==,iv:163v9VopyuNR2DwRH6TxDH+bwLy1YgicuG7VPvtvqw8=,tag:zjE5i/Vsqzzy9xz3cvbWAw==,type:str]
+        nameAttr: ENC[AES256_GCM,data:pxU=,iv:imX5S/tX8VgFaO/gY/NxAfQqEt/JYDGEIuMrwv+jrIY=,tag:AVpDNIQZCqja2YzGbwn72w==,type:str]
+        username: ENC[AES256_GCM,data:EklwFQ==,iv:WF1BE7PKP497h/g3fBYdcr1DAM93Xj2KbrPxkiqLLl4=,tag:KePJj2etNC5POAEcB0DyvA==,type:str]
+      usernamePrompt: ENC[AES256_GCM,data:FJDd60Cs0sILObrOfA==,iv:M7lln1c2kxxCnU9YllIKjx8bz1fPODcgIqNWV+269kI=,tag:05mSJYv2OOjyoqm6fVM2hw==,type:str]
+expiry:
+  idTokens: ENC[AES256_GCM,data:cU2E,iv:zN3kDu2RDUKNcpXOBMqJw+DQjRh/6B+0FdX0ZFWJWjA=,tag:yNFh6lSpGcXK/1R7yQX57w==,type:str]
+  signingKeys: ENC[AES256_GCM,data:38Q=,iv:DWFye2uQVA/rA/4ln0UZT0VRfTs7mEtHQ4yYaXNaIjI=,tag:Slw9sZ8uUngraIvoPvRBXg==,type:str]
+issuer: ENC[AES256_GCM,data:EU7iuOGGKWlWdUHG4iQJDamP1TjULnBZZUI9qg==,iv:AtmpjIRjT8PSOw3IJg7IFfGk+HMCDsiL2yolAHBHvXs=,tag:VD5ug5ZO78UXO4Csf68N2w==,type:str]
+oauth2:
+  responseTypes:
+    - ENC[AES256_GCM,data:lMZw0Q==,iv:/O9d2blACAa6tkzs2DTl5O7tQ+PDLhNiGPv5NGrVZKw=,tag:emLb/kbS1xcP7+MDLaqZsw==,type:str]
+    - ENC[AES256_GCM,data:yxZRfn4=,iv:SHvxM8Kz6q2rYChrHeyQR97aeu1Dq/3G6qa91cpARYo=,tag:Wc0qSW37epgxbLikCDjCJg==,type:str]
+  skipApprovalScreen: ENC[AES256_GCM,data:iYHvRg==,iv:owuQIUUR7EXlbVRXTxBlpqhYzH76aUKzNaVQsZm594c=,tag:fkLmdVcniGj3MwLEOwvBKA==,type:bool]
+sops:
+  version: 3.13.1
+  lastmodified: "2026-06-15T18:09:20Z"
+  mac: ENC[AES256_GCM,data:83Nvrq9K+IxvEmkBBz72ga0gL40tjq5qC94uX2Mid7849LwI5P9NRsvzhuGRppVEHCPGHXyP5p4FBLs8Zcxu0CiOuOx1AQkJss39kQtDa4Xu0PHVhcERQgHiraGDavAHutsyCZWV7MJf1ovnQYGlqGIq0Ub/Pr+6TtqQsAKRitk=,iv:1u+EOnZ/ZhEVAtDUb2euFytkIuOag8Jq43NgKbx65WA=,tag:ZG0HJpKwOQP6tzUor+gKrA==,type:str]
+  unencrypted_suffix: _unencrypted
+  age:
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSArNHlsb2Q4SWZQR2ZjUWlY
+        SVNBQSt1QXVNTXJIVVJTR0tWbFBIQ0RXNnpJCmVBVEUxQW15Wkh1bEZrUDZRQjlH
+        QWVrOUUwWTM2WlpZU0NWQ3Rqb2hmYzgKLS0tIFpWSnlMN2VFeXJCbjByZDFVWW9j
+        UE5YZkl2L1pJUkczd0Q4TFFsUlFxSVEKro4Oj2KjYRQIBH0H4N2pRlGdkzoPq+jl
+        9d23OscUhfSyxq8Umo45bVRcoRgdxgEniw36siwmR8McC7nRWFxkQQ==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age139fcg32lmhxupnz5wjex44jur7v7wzf9rttp2grnjmxhukck5dmqsd9zj5
+staticClients:
+  - name: ENC[AES256_GCM,data:8/iPOa45Pw==,iv:RSnCBRwlAv6nx9k2jh4s60PH4rdd+LY5tw86jjV1/Zc=,tag:ActxiJFmURLA6OIDO0sLgg==,type:str]
+    id: ENC[AES256_GCM,data:PvQXGQ9BMg==,iv:ROKPFZrfcRdp+7PDa+xScl0671QfZ8QlJY07UYl0p6A=,tag:nbWIlS1dOPXrephNjKFwgw==,type:str]
+    secret: ENC[AES256_GCM,data:fXlu6J1cA9Sz5rQcfpDUFbq1EfvKUOrm3PrtronvJaDt6sPxDjaPXGKueUhXGRTl94TT6Rynr/aDe5Pfw95c8w==,iv:sfxqmTytnT5IN+fnjfu/KmcUy+QoXW91khallbcGRuk=,tag:pK+gWG5pDTxTu263srgHWQ==,type:str]
+    redirectURIs:
+      - ENC[AES256_GCM,data:CDS+Xl5m2IbPgDyKGHa39TaFkCTVXosiXgupa2sI6hznxuqlWdZujZfoex2Dekg4RtR6U/SWvJQs,iv:W9Nf9lveMWVdPLbTiwW4qruWCfswbdfzNBcmEeCVCDo=,tag:hE4BemNnP1SWJqJ/3B6JOA==,type:str]
+  - name: ENC[AES256_GCM,data:/r8J0tbRh1eZO3I=,iv:3c8EbfBSdyvxyMJ44KHybPK5irZISiYFsgpDl60UaG0=,tag:ZOd47zA7axrkoORXu0SG4w==,type:str]
+    id: ENC[AES256_GCM,data:5SMkC1/qPtoE8sw=,iv:tJBEaLaeb0faH3tr5iz9PGsJAn27Hhd3R/ueWtkK54c=,tag:QGAQY6SyCp3Gw++q8l7WIA==,type:str]
+    secret: ENC[AES256_GCM,data:TKBU6iP6l5ozt9r3YHRI1d5gMy42aWSFLbF7l11EzHxQY3+6ZX2ZKGTfLGpd3USPf++/LZOFjWr0kvzTT7KFiA==,iv:jmHts7fVv+VU0yD9GHh5mOhp6s4FM5nVg0h6buiNdUc=,tag:lJZRPnAkRVxiZjPw1A5Urg==,type:str]
+    redirectURIs:
+      - ENC[AES256_GCM,data:dUdhY3+GvDVt9JeGx34OHzSknxcn4xx90JCJo0w5XxvJ98qKszSxAy1zt83og/hfZFVcMhwl+uCtQmhPrOWsAZ6ttA==,iv:3G7OMjSZPSy0b/oMzbAESc10UAlIAA8zX0DaBD8JRPQ=,tag:V5ytLuiWeLh/4IA4Pa27Qw==,type:str]
+  - name: ENC[AES256_GCM,data:GNk8IRwPWw==,iv:SIaPyeX7Fx1CIfNrcfaPqCPcWRVkW2F6iiu7g9COSVY=,tag:Zi6YW1FgnvyTJIP24i8whA==,type:str]
+    id: ENC[AES256_GCM,data:bXRa2sYBTw==,iv:Ka8XNUvKMkSjzF+XHux6kYQ22Gn0GdXz2H2lN3r3qgo=,tag:ZapaQSCljVIT3DjLe+CPCQ==,type:str]
+    secret: ENC[AES256_GCM,data:X7r83rHVXYaNXqKx7TZf9nHEk/2NtfKrYaa30q/547oav0CLFOBsqZTpwLoaLGSNNc7HbsUmMW7xZc9BipD89Q==,iv:hAGsQ29SQGWcm2e/LCbIq7WExSGMKUgpM3xBsvsZ/rQ=,tag:GPC/1/AnEUCGDBsMTAywEw==,type:str]
+    redirectURIs:
+      - ENC[AES256_GCM,data:W+uD6ggYS4M+9SK6Y0wKrNNneTl/CBVPFKKtDUgzf2SaeaY11CH6YX/v3F/w50J6J1QO64K89XF/slDi3A==,iv:+X+wulmZpA0ndQajCW2m/m7XBlEx7Fhze15n7Lg93F8=,tag:J+svN9WvuLwLEp6K4ZBzDw==,type:str]
+  - name: ENC[AES256_GCM,data:tN5Tj4k=,iv:FrmiC9uPxiKD8vYwAj9qYlsHh8DP65otXMuoraxMtpA=,tag:Vl133hDc6NQ66nzMfplBRA==,type:str]
+    id: ENC[AES256_GCM,data:u67VafA=,iv:BnJiRkkgRmmGSz13Xt0nUdaS2ZId//Jj1xpQRus/KoA=,tag:DgdA3VKkNVes0KLJHWI59Q==,type:str]
+    secret: ENC[AES256_GCM,data:YL8ZE7wF2wwp8EFTQBSMUPCNZgaisp8sLKvsO2sG3aTEhdcUD3in2hLj78WyoMr2do2+LgU6vVSF7j6uR2JEBg==,iv:msUoLb0HTQSrDLCym1iR1fr+CVlCzn2u2VsC4SWpEwI=,tag:2EFnkB25cEMr8IViQz0X8g==,type:str]
+    redirectURIs:
+      - ENC[AES256_GCM,data:pyntGGnX09zYUNGSeKpmNTS2vQiGUCv6rcms13UAr9troMu/Wk/OhyDBR+Hx9BNMVY8o,iv:wuhN2pC9n+qU8mvgZnqYHzqZ+sHsm6ERDxtWv2DD5yg=,tag:oyaSmJ+9kpUN+PNxQze/8w==,type:str]
+  - name: ENC[AES256_GCM,data:UuIHx5hLZrmT,iv:u8+e+g7y93aoZfRUMXhOPLRIc/2bOUKbnxfxa5o7mzg=,tag:Tz000q1Fsk8tXayi6naBGA==,type:str]
+    id: ENC[AES256_GCM,data:Qa/yZgOcvxcN,iv:IDxn7ur3iUBr2l2jPYswGjOVo5AxvaPYjDFR4KXRRx4=,tag:m3WVEsVvkE/fX7dv1eyLlw==,type:str]
+    secret: ENC[AES256_GCM,data:JYwBsqbvzSQ5RtZufJlefXzAsSY5plRQQ5wBoHLjtgNojQQPGCr2IrWhOkbMquz+q/zWUXIMEtjuAe1unAf+rw==,iv:SH+E+ioWtUXEhnW+vOp+NaBaseh6/AGIAacLapatgeA=,tag:s44h1KfUL6MoJNrvsjwP6g==,type:str]
+    redirectURIs:
+      - ENC[AES256_GCM,data:30MjNUnHYNofX3G5AXNwShVWFkrzqp3GfBoIOA2HAiGtTeh8aoVa5yzhEU9c8WLB8Q==,iv:lRNT+m8NZ0VqUHEYoIWglE2n/4RU51/Ttmp+fI/tJFs=,tag:epng4uHUigAPtP9Dxktijw==,type:str]
+  - name: ENC[AES256_GCM,data:TTukkO5gaZea3Os+,iv:YEj1mjTMPWhVcDJCrBDNWf/Gb3VziiOj1OxFd+sES2I=,tag:zWdkFVEXlErdtSLXzLizAQ==,type:str]
+    id: ENC[AES256_GCM,data:AYUeg1g4hJpGhJab,iv:yRFy6Ig2klObvzOywW5q7AuRw5knPhCKOZgBXudyG2Q=,tag:O9Iv4eVt/7PaQfyI1uu46w==,type:str]
+    secret: ENC[AES256_GCM,data:H8P4d1ZIdslB4/dgsGghYD4kA1/PuZJ8Sc9LDRUdM36ekvFm/3vUh8ORxZiL76/o9Y9h1udCQ236CJbFP9FEvA==,iv:OKj2EPHggvTzUbduC5DfPruQuLjDkghHNOCx7tmlGrc=,tag:QZol5FRd1f8apPY9UxUcdw==,type:str]
+    redirectURIs:
+      - ENC[AES256_GCM,data:vnu2vrHozj/aVnzXRvnDcOlZYvVOR4h18ng6Ng1MpPotZidQn/iXrb6pHykj5EcczTbVot8nbtXMK3PHLvc=,iv:twOhD66uD6ub8WTi6TJBJ1pqzKjbwl9Rg0YAuUO/swA=,tag:mUIMAF8gPFVOtIA/4COEHQ==,type:str]
+storage:
+  type: ENC[AES256_GCM,data:CEWj1wKGQg==,iv:clxedEU4b/TYphGHUFYbxMFSpxsS6ySh3Bei8HUDWfo=,tag:9qovBQ0VTb4qi3mwKM+I7w==,type:str]
+  config:
+    file: ENC[AES256_GCM,data:pKRggsM5UnHwS2BR/IWd,iv:7HGvVV4AlnWYuPlmsRtIMjlCvBCyuRb6IteQcA9x6Wo=,tag:gn3U87zjZs1XELtoHfKmMg==,type:str]
+web:
+  http: ENC[AES256_GCM,data:6pJNC+DrS7kPu7BC,iv:HnfUF97ZAes46mPlE2+WLLTAdepyB/HuUjT/yTDe5Bg=,tag:RDSWv8XhGzuCJRlD5Te9hw==,type:str]

--- a/apps/dex/overlays/nishir/kustomization.yaml
+++ b/apps/dex/overlays/nishir/kustomization.yaml
@@ -1,0 +1,7 @@
+resources:
+  - ../../base
+namespace: shikanime
+secretGenerator:
+  - name: dex
+    files:
+      - config.yaml=dex/config.enc.yaml

--- a/apps/openldap/base/cert.yaml
+++ b/apps/openldap/base/cert.yaml
@@ -1,0 +1,20 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: openldap
+spec:
+  dnsNames:
+    - openldap
+    - openldap.shikanime.svc.cluster.local
+  duration: 2160h
+  isCA: false
+  issuerRef:
+    name: nishir
+    kind: ClusterIssuer
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  renewBefore: 720h
+  secretName: openldap-tls
+  usages:
+    - server auth

--- a/apps/openldap/base/kustomization.yaml
+++ b/apps/openldap/base/kustomization.yaml
@@ -1,0 +1,6 @@
+resources:
+  - sts.yaml
+  - svc.yaml
+  - pvc.yaml
+  - cert.yaml
+  - netpol.yaml

--- a/apps/openldap/base/netpol.yaml
+++ b/apps/openldap/base/netpol.yaml
@@ -1,0 +1,16 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: openldap
+spec:
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: shikanime
+      ports:
+        - port: ldap
+        - port: ldaps
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/instance: openldap

--- a/apps/openldap/base/pvc.yaml
+++ b/apps/openldap/base/pvc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: openldap
+spec:
+  resources:
+    requests:
+      storage: 5Gi
+  storageClassName: longhorn
+  accessModes:
+    - ReadWriteOnce

--- a/apps/openldap/base/sts.yaml
+++ b/apps/openldap/base/sts.yaml
@@ -1,0 +1,72 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: openldap
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: openldap
+      app.kubernetes.io/name: openldap
+  serviceName: openldap
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/instance: openldap
+        app.kubernetes.io/name: openldap
+    spec:
+      containers:
+        - name: openldap
+          image: osixia/openldap:1.5.0
+          livenessProbe:
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            tcpSocket:
+              port: ldaps
+          ports:
+            - name: ldap
+              containerPort: 389
+            - name: ldaps
+              containerPort: 636
+          readinessProbe:
+            initialDelaySeconds: 10
+            periodSeconds: 5
+            tcpSocket:
+              port: ldaps
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/ldap
+            - name: data
+              mountPath: /etc/ldap/slapd.d
+              subPath: config
+            - name: certs
+              mountPath: /container/service/slapd/assets/certs
+          envFrom:
+            - secretRef:
+                name: openldap
+      initContainers:
+        - name: tls-cert
+          image: alpine:3.20
+          command:
+            - sh
+            - -c
+            - |
+              cp /tls/tls.crt /certs/tls.crt
+              cp /tls/tls.key /certs/tls.key
+              chmod 600 /certs/tls.key
+          volumeMounts:
+            - name: tls-secret
+              mountPath: /tls
+            - name: certs
+              mountPath: /certs
+      securityContext:
+        fsGroup: 1001
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: openldap
+        - name: certs
+          emptyDir: {}
+        - name: tls-secret
+          secret:
+            secretName: openldap-tls

--- a/apps/openldap/base/svc.yaml
+++ b/apps/openldap/base/svc.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: openldap
+spec:
+  ports:
+    - name: ldap
+      port: 389
+      targetPort: ldap
+    - name: ldaps
+      port: 636
+      targetPort: ldaps
+  selector:
+    app.kubernetes.io/instance: openldap
+    app.kubernetes.io/name: openldap

--- a/apps/openldap/overlays/nishir/.enc.env
+++ b/apps/openldap/overlays/nishir/.enc.env
@@ -1,0 +1,16 @@
+LDAP_ORGANISATIONS=ENC[AES256_GCM,data:pwofixn/vZFm5eOTB/Xh2Q==,iv:hdtgxFZFu9i367EteZAMpyoh9tEZczPo4aVbtWN+wI4=,tag:pFePqnhh+Bd7ctoCCw8bAw==,type:str]
+LDAP_DOMAIN=ENC[AES256_GCM,data:3Mrcq87QenE1RsO/wu1Eqg==,iv:unhsOWVhV+A77ZxRIqudJSaIhTVjeFnz01myQhq/wNo=,tag:m8TCT42Ro8PhWOSlU/n6Sg==,type:str]
+LDAP_ADMIN_PASSWORD=ENC[AES256_GCM,data:KTW1GuSBGwB2GcbqOah4aab5cZlAz7nyW+/tpR1QZXAevlUEd7FLFOlY/g==,iv:btpO/tlS/5L0MCSfHB2jgIl+RTpqlCoqIyNmlRyvIbI=,tag:AQlActM3HSRNgSVhicBYZA==,type:str]
+LDAP_CONFIG_PASSWORD=ENC[AES256_GCM,data:necNtqUlFBrMqkT//B9J1QLXW8HrAGeuNrINTqTdsHLCxD7E5+1IEsEwZQ==,iv:sS57daJB56IwpfU266TITI/1Amo4mS/CWeX3d7Uq9Ow=,tag:NaRk4bdaHVrGgnLGVm7qxg==,type:str]
+LDAP_TLS=ENC[AES256_GCM,data:P4QnEA==,iv:F5LzmhEPbDmyFRBx1yQbw5WII6eYdu32L2xXnyaBNz0=,tag:VU8hN+Oa+yFgE/98vSnGPQ==,type:str]
+LDAP_TLS_ENFORCE=ENC[AES256_GCM,data:qg8P4g==,iv:OOh+3+09HRp0YmMdFezEpntroDekkErZjrwj86zAAng=,tag:rvPALpMsd1jtwdpAwb8wsw==,type:str]
+LDAP_TLS_CRT_FILENAME=ENC[AES256_GCM,data:bVEaY56M2Q==,iv:SjKFQcEqwKqsa+M/2aYdBPMqwzDd0OcPel4e6OuFsWA=,tag:CZi3s01BUK4dHy+Vnqnfnw==,type:str]
+LDAP_TLS_KEY_FILENAME=ENC[AES256_GCM,data:t+75y87OuA==,iv:CUIzza0pbEY1gfMmCXykBjyClsmoxJZ+SAPSC3v8FMg=,tag:JsCGNdTmmsROlJYZ+cgtAA==,type:str]
+LDAP_TLS_CA_CRT_FILENAME=
+LDAP_READONLY_USER=ENC[AES256_GCM,data:2xo6ysM=,iv:WrAGgXMUeWJGS7MJo8OEuq5saJolFZ41heEjsvuYwRY=,tag:4L42BSEDDJ+rYYWvLhU/cQ==,type:str]
+sops_age__list_0__map_enc=-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBJVXl4d3B5YW93Rlk3Ynh6\nQ2M0R1JlTXI5NXo2M2xuZVRCSlowa3h1aEYwCkRBRjZNOS9SU1RiOW91eFFPaDRR\nR2xXa25leVFmWUFzbGFLWit5MnJxSFEKLS0tIHB2WTR1RW1pVlA5OC83dzJqSVNJ\nVlV5c1liQjhHZXRZQXB4N1J5S28ycWsKMv0siwyPiCx09BjR1skLwgQL+c5o2+UW\nbkuAvcneOKhw7pJjnbqKgDTP8ayaJqJZb+JLZXHhpgB1hfePSLyYlw==\n-----END AGE ENCRYPTED FILE-----\n
+sops_age__list_0__map_recipient=age139fcg32lmhxupnz5wjex44jur7v7wzf9rttp2grnjmxhukck5dmqsd9zj5
+sops_lastmodified=2026-06-15T18:06:49Z
+sops_mac=ENC[AES256_GCM,data:M6cgwNge0eK6XcugFHANuZpbgHwd6QTQKXxvgknfKOtpmmqBFn0uIPLPBnsFBzD7loYIl2voMXsvYDYd/x83WyO1Dw/bvVVO2k+PqpQvj+G3uOGdSVjEWlM6re3qXKJ7P9Kw1Y5c9kKVp4hawpPKSEiXSk+eV8Gybz61ZIb3fh8=,iv:zgkaB2S5OpC8UNgn0TV93OB7WF/+SkUktX5OKy4d6EI=,tag:W4Mx+WX3ifwHrZYbyWaNEg==,type:str]
+sops_unencrypted_suffix=_unencrypted
+sops_version=3.13.1

--- a/apps/openldap/overlays/nishir/kustomization.yaml
+++ b/apps/openldap/overlays/nishir/kustomization.yaml
@@ -1,0 +1,19 @@
+resources:
+  - ../../base
+  - seed-job.yaml
+namespace: shikanime
+configMapGenerator:
+  - name: openldap-seed
+    files:
+      - seed.ldif
+  - name: sso-config
+    literals:
+      - LDAP_SERVER=openldap.shikanime.svc.cluster.local
+      - LDAP_BASE_DN=dc=shikanime,dc=studio
+      - LDAP_TLS=true
+      - OIDC_ISSUER=https://dex.shikanime.ts.net
+      - OIDC_SCOPES=openid email profile groups
+secretGenerator:
+  - name: openldap
+    envs:
+      - .enc.env

--- a/apps/openldap/overlays/nishir/seed-job.yaml
+++ b/apps/openldap/overlays/nishir/seed-job.yaml
@@ -1,0 +1,34 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: openldap-seed
+spec:
+  backoffLimit: 3
+  template:
+    spec:
+      containers:
+        - name: ldapadd
+          image: osixia/openldap:1.5.0
+          command:
+            - ldapadd
+            - -x
+            - -H
+            - ldaps://openldap:636
+            - -D
+            - cn=admin,dc=shikanime,dc=studio
+            - -w
+            - $(LDAP_ADMIN_PASSWORD)
+            - -f
+            - /seed/seed.ldif
+            - -Z
+          volumeMounts:
+            - name: seed
+              mountPath: /seed
+          envFrom:
+            - secretRef:
+                name: openldap
+      restartPolicy: OnFailure
+      volumes:
+        - name: seed
+          configMap:
+            name: openldap-seed

--- a/apps/openldap/overlays/nishir/seed.ldif
+++ b/apps/openldap/overlays/nishir/seed.ldif
@@ -1,0 +1,22 @@
+# Base structure
+dn: ou=people,dc=shikanime,dc=studio
+objectClass: organizationalUnit
+ou: people
+
+dn: ou=groups,dc=shikanime,dc=studio
+objectClass: organizationalUnit
+ou: groups
+
+# Admin group
+dn: cn=admins,ou=groups,dc=shikanime,dc=studio
+objectClass: groupOfNames
+cn: admins
+member: cn=admin,ou=people,dc=shikanime,dc=studio
+
+# Admin user
+dn: cn=admin,ou=people,dc=shikanime,dc=studio
+objectClass: inetOrgPerson
+cn: admin
+sn: Admin
+mail: admin@shikanime.studio
+userPassword: $2b$12$8CU0K17kv0FCnDowsj7jOe/5KMhd9Y74Azc6nP00bhJl7.vYm3RTa

--- a/apps/syncthing/overlays/nishir/httproute.yaml
+++ b/apps/syncthing/overlays/nishir/httproute.yaml
@@ -7,6 +7,8 @@ spec:
     - syncthing.taila659a.ts.net
   parentRefs:
     - name: nishir
+      sectionName: http
+    - name: nishir
       sectionName: https
   rules:
     - backendRefs:

--- a/clusters/nishir/overlays/tailnet/ks.yaml
+++ b/clusters/nishir/overlays/tailnet/ks.yaml
@@ -239,6 +239,7 @@ spec:
     secretRef:
       name: sops-age
   dependsOn:
+    - name: apps-openldap
     - name: infrastructure-autoscaler
     - name: infrastructure-cert-manager
     - name: infrastructure-tailscale
@@ -785,6 +786,56 @@ spec:
       namespace: shikanime
   interval: 10m
   path: ./apps/servarr/whisparr/overlays/nishir-tailnet
+  prune: true
+  sourceRef:
+    name: flux-system
+    kind: GitRepository
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: apps-openldap
+  namespace: flux-system
+spec:
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-age
+  dependsOn:
+    - name: infrastructure-cert-manager
+  healthChecks:
+    - apiVersion: apps/v1
+      kind: StatefulSet
+      name: openldap
+      namespace: shikanime
+  interval: 10m
+  path: ./apps/openldap/overlays/nishir
+  prune: true
+  sourceRef:
+    name: flux-system
+    kind: GitRepository
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: apps-dex
+  namespace: flux-system
+spec:
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-age
+  dependsOn:
+    - name: apps-openldap
+    - name: infrastructure-cert-manager
+    - name: infrastructure-tailscale
+  healthChecks:
+    - apiVersion: apps/v1
+      kind: Deployment
+      name: dex
+      namespace: shikanime
+  interval: 10m
+  path: ./apps/dex/overlays/nishir-tailnet
   prune: true
   sourceRef:
     name: flux-system


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* __->__ #1669

Adds OpenLDAP StatefulSet with cert-manager TLS and seed job, plus Dex
Deployment with file-backed config. Both exposed via Flux Kustomizations
in the nishir tailnet overlay.

Signed-off-by: William Phetsinorath <william.phetsinorath@shikanime.studio>