### PR TITLE
Integrate OIDC/LDAP connectors into apps

### DIFF
--- a/apps/copyparty/overlays/nishir-tailnet/copyparty/oidc.enc.conf
+++ b/apps/copyparty/overlays/nishir-tailnet/copyparty/oidc.enc.conf
@@ -1,0 +1,14 @@
+{
+	"data": "ENC[AES256_GCM,data:fC8L9OIwGjw8Ge7x8MhzYNxNiR8rE3efJ6xwOpwOLQqmFZ/0DGzErt6vx8q3F4SbKsG5M34Mde9OsEaBY4Ho515na7nmSnwnTIsK7ulM7ZnSzIKSh+FdPnNGMM56/yVFjgd0HnLcf4Y4wrtyOoE3n4uMTKWFJ9N0H0oDn4xA1TrDFhQi23tk1U37rzkbLNkpCZnBVak5H7yUzpplwvpYfgsWw6VpX5mVRDrWaih33OmU32/UUnYfaVOTnOpQiDRjZ0mPI69QAI3xYt76ZBWqwMSt6Pl3UxBGREf9SzWogRS/SZU1CKa8jg==,iv:Db861hOjEyQWmccashvUO9Ci72aatDmQ5/D0+YSlPC0=,tag:fikKohz4VFZWSsye5+S4qQ==,type:str]",
+	"sops": {
+		"age": [
+			{
+				"enc": "-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBDSzB4TzF3NlFPWlhFZGov\nVXBFVzVGZHFBYzVOUmUvMTBnblNFcWtzalJRCmtSN3lkRFU4VlFDNEFJTSsyVDk5\nRVdWZVJHcyswdWpLMmZHM3JWYWIvWGMKLS0tIEVMeGRqekhHVjlqNGd0NXpyMWFU\nQ2VZV1QzbkNQNzBoZFZWdDc4UjFMR2sK/JfRSubbEeXgztGMt7AhjQM5CxFFZCXl\nidDdD/QxaHfzalr0759ZCpr2BTRll8mEE/RHI1Qllhfp2WuLeCpFhg==\n-----END AGE ENCRYPTED FILE-----\n",
+				"recipient": "age139fcg32lmhxupnz5wjex44jur7v7wzf9rttp2grnjmxhukck5dmqsd9zj5"
+			}
+		],
+		"lastmodified": "2026-06-15T18:19:13Z",
+		"mac": "ENC[AES256_GCM,data:896QTAxBHxqP2MPTveweBkdBzT1X7Fpe/nKOX9B3g2TyC8zAEekDwjyiYZyGXtzej/wCofsSIcbSl4sNVdJfNrrmNn15ZcX8/uL2nz4pVgBYFAaMT2pcFxoDzOXKb7kzl8uuJ4+6YGengaL34todlBm5k47QoKgpkVvbOPBOVr8=,iv:xY3bjgcOpO4TmA6/CpNCvHbfBoeqEgrQntAsy98K1p4=,tag:HLJ1E/AJro8ZxHAmYBz35A==,type:str]",
+		"version": "3.13.1"
+	}
+}

--- a/apps/copyparty/overlays/nishir-tailnet/kustomization.yaml
+++ b/apps/copyparty/overlays/nishir-tailnet/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
 namespace: shikanime
 patches:
   - path: patch-svc.yaml
+  - path: patch-sts-oidc.yaml
 configMapGenerator:
   - name: copyparty
     files:
@@ -17,3 +18,7 @@ labels:
       app.kubernetes.io/name: copyparty
       app.kubernetes.io/part-of: nishir-operation
       app.kubernetes.io/version: 1.20.16
+secretGenerator:
+  - name: copyparty-oidc
+    files:
+      - oidc.conf=copyparty/oidc.enc.conf

--- a/apps/copyparty/overlays/nishir-tailnet/patch-sts-oidc.yaml
+++ b/apps/copyparty/overlays/nishir-tailnet/patch-sts-oidc.yaml
@@ -1,0 +1,29 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: copyparty
+spec:
+  template:
+    spec:
+      initContainers:
+        - name: oidc-config-merge
+          image: busybox:1.37
+          command:
+            - sh
+            - -c
+            - |
+              # Append OIDC config to copyparty config.conf
+              if [ -f /mnt/oidc-config/oidc.conf ]; then
+                echo "" >> /config/config.conf
+                echo "# Dex OIDC configuration" >> /config/config.conf
+                cat /mnt/oidc-config/oidc.conf >> /config/config.conf
+              fi
+          volumeMounts:
+            - name: config
+              mountPath: /config
+            - name: oidc-config
+              mountPath: /mnt/oidc-config
+      volumes:
+        - name: oidc-config
+          secret:
+            secretName: copyparty-oidc

--- a/apps/forgejo/overlays/nishir-tailnet/forgejo/oidc.enc.ini
+++ b/apps/forgejo/overlays/nishir-tailnet/forgejo/oidc.enc.ini
@@ -1,0 +1,22 @@
+[oauth2_client]
+ENABLE                 = ENC[AES256_GCM,data:JLKeqA==,iv:NrrjuGeUv1FU2MXhFLnIA1FgJ4H7uVOIyl3nULKoMWk=,tag:Z9LAvGKYvlDWdDYQ0Gqf6w==,type:str]
+PROVIDER               = ENC[AES256_GCM,data:nRo3eg==,iv:BkbRK0lwVuY0H61LuIIRDvesSvH5i23jCzV+zHOV5TM=,tag:rOZaRzYMXkqd/8upsY+oTA==,type:str]
+CLIENT_ID              = ENC[AES256_GCM,data:i7uVX1Dg2w==,iv:CgVFJ+KylyGNXBmmrcQYYMthb5xQi4Fl4qA6Gfv2oIM=,tag:h49WwF88Vet65w866B5HJQ==,type:str]
+CLIENT_SECRET          = ENC[AES256_GCM,data:AAZ5f/rker7ow0Idu6FFO/o4QQMYA9L9Tkk3qEJeFRo70Jp9D5NIXwXFRemksKznNYZfJ+rLvNVYOT8pnFuckQ==,iv:77Omiysf7tf5mV3Hcld29r5Qei7VRey2n+2q4rfOslg=,tag:08eKcjLE1SJA135nJZfBAA==,type:str]
+OPENID_CONNECT_SCOPES  = ENC[AES256_GCM,data:m/PjQd05wMFKgNsdOQMMqE0hyGdWT26cHyTK,iv:JkipUiTsu8tlZvJ0LO1Lwr5P72hL5YAz/rkc299plmA=,tag:iIjHr6+ilHxvea1rj0VvoA==,type:str]
+AUTO_LINK_OIDC_ACCOUNT = ENC[AES256_GCM,data:LlZkGg==,iv:j2vQap1QFZf/03BWXlk6WeLtmNxisuZkwAcB1VcFRBE=,tag:y6K+aUUOV2v4cbXAVQ1AsA==,type:str]
+
+[sops]
+age__list_0__map_enc       = """-----BEGIN AGE ENCRYPTED FILE-----
+YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAvY2QvYzhyMS92RkdpQU53
+am1WQTFEUHlxOGJ5WVA0eEpGdUtpRzUxYlRrCmJEWjJpNjdSVndDdThVZlNWOWlS
+OU4yY21OZzJVK2xDUjQ4Tmd3TzRiSE0KLS0tIGNKcjFERlpLZkpaRXQzN1Iva3p1
+U05uWDl4bkxuTzdrNy9zcnJzUWlBZ0UKnQ7Go5T5AT2TZoFLJXuwZWb14/vGRNDV
+jCfBIroGrqe9nKhJ90YHXfApER98M5hCnxammgk/l7ZhLhKt4E6qDA==
+-----END AGE ENCRYPTED FILE-----
+"""
+age__list_0__map_recipient = age139fcg32lmhxupnz5wjex44jur7v7wzf9rttp2grnjmxhukck5dmqsd9zj5
+lastmodified               = 2026-06-15T18:16:19Z
+mac                        = ENC[AES256_GCM,data:eTcyhtbE4YLSmFsWp/12g71wq4UskrK7qLzCrgCTYdDiMGhEVPoUac62DPr6+GAcDYnzWVolMNBT8thTUGVpW+5fTXMe/k4YJj0vZ/vYsXkqZDS5ZAQKO5GStVWDF3nMtXm3h/M7I09Tiw+TzypD6GH9244wMopYWo3heWHokV8=,iv:kB6OzIwBM1R+eZ7wtWjTb24SqB619TOboRzoJHFE6MU=,tag:Cw4Mnu23aXNTwE/aa+rabw==,type:str]
+unencrypted_suffix         = _unencrypted
+version                    = 3.13.1

--- a/apps/forgejo/overlays/nishir-tailnet/kustomization.yaml
+++ b/apps/forgejo/overlays/nishir-tailnet/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
 namespace: shikanime
 patches:
   - path: patch-svc.yaml
+  - path: patch-sts-oidc.yaml
 labels:
   - includeTemplates: true
     pairs:
@@ -17,3 +18,6 @@ secretGenerator:
   - name: forgejo-config
     files:
       - app.ini=forgejo/app.enc.ini
+  - name: forgejo-oidc
+    files:
+      - oidc.ini=forgejo/oidc.enc.ini

--- a/apps/forgejo/overlays/nishir-tailnet/patch-sts-oidc.yaml
+++ b/apps/forgejo/overlays/nishir-tailnet/patch-sts-oidc.yaml
@@ -1,0 +1,29 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: forgejo
+spec:
+  template:
+    spec:
+      initContainers:
+        - name: oidc-config-merge
+          image: busybox:1.37
+          command:
+            - sh
+            - -c
+            - |
+              # Append OIDC config to app.ini after the main config-sync init-container
+              if [ -f /mnt/oidc-config/oidc.ini ]; then
+                echo "" >> /var/lib/gitea/custom/conf/app.ini
+                echo "# Dex OIDC configuration" >> /var/lib/gitea/custom/conf/app.ini
+                cat /mnt/oidc-config/oidc.ini >> /var/lib/gitea/custom/conf/app.ini
+              fi
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/gitea
+            - name: oidc-config
+              mountPath: /mnt/oidc-config
+      volumes:
+        - name: oidc-config
+          secret:
+            secretName: forgejo-oidc

--- a/apps/gitea-mirror/overlays/nishir-tailnet/gitea-mirror/oidc.enc.env
+++ b/apps/gitea-mirror/overlays/nishir-tailnet/gitea-mirror/oidc.enc.env
@@ -1,0 +1,10 @@
+OAUTH2_CLIENT_ID=ENC[AES256_GCM,data:TTOeIiX2a8cU74sw,iv:I2XYyyf7vydDtHDhKm7a/CIS9OE1tEd/YqA8VirYYoc=,tag:tmcmxXdQu1aFloHp4t+vJQ==,type:str]
+OAUTH2_CLIENT_SECRET=ENC[AES256_GCM,data:x5UcpeFcy1ekFH3hTasVxPxh7cESfrl0wE964ZM7qsZA+q3XrgjS9IuRczGoPcE97rmvN4ITiEptg1afaUJlNg==,iv:w52DQonk2SiLgA0NJtU53DxZzA7ycA4sAwFzyiIxYWo=,tag:SgWx/KW43jKb1iluvc0bfA==,type:str]
+OAUTH2_PROVIDER=ENC[AES256_GCM,data:6Pvsyg==,iv:f2xjtLUctB5/KpUp2Ls6KReEoXRM8GytDf2MiTq9uhI=,tag:KzfxVXLLwNChVsxR0bWpzA==,type:str]
+OAUTH2_OPENID_CONNECT_SCOPES=ENC[AES256_GCM,data:TMBlmp4kR065KZ2yAoeQjBffZzc=,iv:I9/fo84mRjTGR0XHXe044UhNUIn3s7q8+iv2dYHht5w=,tag:8tMQFN7CxLZXcDHlsBQBvQ==,type:str]
+sops_age__list_0__map_enc=-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB0bVNpYzE1ZjYybksrMmJX\nL0ZFd1N3U1lwTk5CdFZZWkkwWjNESHE0WVFFCmJON3AvUjJUSmp5a3Q1cHI2bFha\nSDJZRE9lWHduSFpCdVF5TCs0ZWR3cUEKLS0tIDd3TU5pTjl0MUxXRHBPSFBLRjVL\nSTA5SHhmTzVGZ2FKK1R2QWpTa1p2L0EKTeB8BgyOIhsMKjYDvR9eOcxhe8y9CjTc\n45ku/YG/J+3NVmd57BTntby/su4GNloz7/ZSMnArz9grmVeheKDnEg==\n-----END AGE ENCRYPTED FILE-----\n
+sops_age__list_0__map_recipient=age139fcg32lmhxupnz5wjex44jur7v7wzf9rttp2grnjmxhukck5dmqsd9zj5
+sops_lastmodified=2026-06-15T18:19:13Z
+sops_mac=ENC[AES256_GCM,data:c32VXftL3m0RESc/7e4gke7Dulrycrp81sUme1jpW5Ps2ZINH8yyqzSGboQWUMwWXdXc+m32HsBVbRupW5mF/JD9xdJXFTABGqXhkto3njlBLrRtsz1uF+xcT+IRrVbq1Vt/Xy7EUX9ytc+A56+ynAldAb7R518DyvkHOeOSQWY=,iv:PDZa8KtWGN2H+glJMuZNZKi9KlpmKL2zqocR3+nAKSw=,tag:BAdSMwktX2JEpe8j6zSn5A==,type:str]
+sops_unencrypted_suffix=_unencrypted
+sops_version=3.13.1

--- a/apps/gitea-mirror/overlays/nishir-tailnet/kustomization.yaml
+++ b/apps/gitea-mirror/overlays/nishir-tailnet/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
 namespace: shikanime
 patches:
   - path: patch-sts.yaml
+  - path: patch-sts-oidc.yaml
 labels:
   - includeTemplates: true
     pairs:
@@ -17,3 +18,6 @@ secretGenerator:
   - name: gitea-mirror
     envs:
       - gitea-mirror/.enc.env
+  - name: gitea-mirror-oidc
+    envs:
+      - gitea-mirror/oidc.enc.env

--- a/apps/gitea-mirror/overlays/nishir-tailnet/patch-sts-oidc.yaml
+++ b/apps/gitea-mirror/overlays/nishir-tailnet/patch-sts-oidc.yaml
@@ -1,0 +1,12 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: gitea-mirror
+spec:
+  template:
+    spec:
+      containers:
+        - name: gitea-mirror
+          envFrom:
+            - secretRef:
+                name: gitea-mirror-oidc

--- a/apps/jellyfin/overlays/nishir-tailnet/jellyfin/ldap.enc.env
+++ b/apps/jellyfin/overlays/nishir-tailnet/jellyfin/ldap.enc.env
@@ -1,0 +1,13 @@
+LDAP_SERVER=ENC[AES256_GCM,data:Aw6PQHNQrcHd5Jga,iv:cXFCKAf2KqWymju70fdx0a/29hAObfX7mv+Lz/d37b0=,tag:QiP3sNO560ELBnWzyA7ZTA==,type:str]
+LDAP_BASE_DN=ENC[AES256_GCM,data:JEo9CCf/bOwu9Was+mE5AFTmv/Qn0Z3R/LEu7iMblW4=,iv:lUioOsGuyRywSJr7MtGij2LGKd6LCHe/GtIddtik6LY=,tag:12+IXY23s0co+4NK1qHIyA==,type:str]
+LDAP_BIND_DN=ENC[AES256_GCM,data:Ua+jqdv9YRHYnsZuB6ANn/kv1GiQ20qq9WwUbS6fmg==,iv:32sxUvOv3iCOxX4Dh1MkiJ9WQfs6bk0h7nMyMmJBE8I=,tag:hsVt76S3aJwmO0ohKGMnNA==,type:str]
+LDAP_BIND_PASSWORD=ENC[AES256_GCM,data:RFql7Zs7MCgDrHt/ag8HSIjabi/WC34dkLykvnhEwOWcdEZi6vPNs5jeDA==,iv:ImWI7ePHwqEvD9yg62wZPdMmLEfwis1CHOMG2JSXuoM=,tag:C/2lzhGDfHQVwLsQP6wkLA==,type:str]
+LDAP_SEARCH_FILTER=ENC[AES256_GCM,data:ZcSbx5iKqizVoonEU7SqpFM=,iv:YGBbatiHfIhRzjZ90io6JNpDjOfX+pfXp9kLaQHu68I=,tag:ygFYlNDvOHc18Hv+/dOGyw==,type:str]
+LDAP_TLS=ENC[AES256_GCM,data:UnY10A==,iv:vorMqC8h6SPfKowOT9OnmzQhEd3+q2uH9BsbtFBAFYw=,tag:d1QJ/mREP4cdUGCSEDVjjQ==,type:str]
+LDAP_CA_CERT=ENC[AES256_GCM,data:E8Qv5hv2++BA8TD/Et6Oqv1klts9nnEmh0hvTQ==,iv:YSARS0DuAO0MYrzeaACUV44v1vCzjot3Ud848CeYt6Y=,tag:UCvD7zE5zh6NoczxQlyhBg==,type:str]
+sops_age__list_0__map_enc=-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBLaHNFU25FWk5ibVFxSlZh\neFdud1VPdzZkQk5DS092V1ROVk0wNkliMVUwCk9Bc3kra3JITVk4bG92ZDVBaWV3\nZkNwL2hXVTRQYmJPK0tRTXFlOTdtYVkKLS0tIEMrZlVybWR5TzZLMHJoZU4yOUsz\nU3BsQzlESTJyUG9pRUtTNjBYZHdjTUUKZGtUI1jnG7sJ6uwdQxI6gg10u8ADsNBF\nrDpODzcoHOD9fKNyQCtR4B7GL3FQIuGHav3Lx68iSlNNnLgmW4rQvg==\n-----END AGE ENCRYPTED FILE-----\n
+sops_age__list_0__map_recipient=age139fcg32lmhxupnz5wjex44jur7v7wzf9rttp2grnjmxhukck5dmqsd9zj5
+sops_lastmodified=2026-06-15T18:20:38Z
+sops_mac=ENC[AES256_GCM,data:MGc95NgzSHpq9RCQh+xqdKq/BA8tuCbKWjukBvR/Uu1YPg4iuBobEMeXTBrgwDhMQG4XTdSxpY3VGaeSCDDmErm4TecJv2dzVFdVx3KggQ+wZN7nHEQ8P8X7TT7rfby3BZJRlrp8KEORRbka3/MXLELTc8oF0LOcLpHUqrnAkAA=,iv:TvJdSsU4bu1RBVr7iSGE0MpyNNaa2mPCTijc3Og+m9M=,tag:WLPKSrd8hcibsMH4+kLRYg==,type:str]
+sops_unencrypted_suffix=_unencrypted
+sops_version=3.13.1

--- a/apps/jellyfin/overlays/nishir-tailnet/kustomization.yaml
+++ b/apps/jellyfin/overlays/nishir-tailnet/kustomization.yaml
@@ -5,6 +5,11 @@ resources:
 namespace: shikanime
 patches:
   - path: patch-sts.yaml
+  - path: patch-sts-ldap.yaml
+secretGenerator:
+  - name: jellyfin-ldap
+    envs:
+      - jellyfin/ldap.enc.env
 labels:
   - includeTemplates: true
     pairs:

--- a/apps/jellyfin/overlays/nishir-tailnet/patch-sts-ldap.yaml
+++ b/apps/jellyfin/overlays/nishir-tailnet/patch-sts-ldap.yaml
@@ -1,0 +1,46 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: jellyfin
+spec:
+  template:
+    spec:
+      containers:
+        - name: jellyfin
+          volumeMounts:
+            - name: ldap-ca
+              mountPath: /etc/jellyfin/ldap-ca
+              readOnly: true
+          envFrom:
+            - configMapRef:
+                name: sso-config
+            - secretRef:
+                name: jellyfin-ldap
+      initContainers:
+        - name: install-ldap-plugin
+          image: busybox:1.37
+          command:
+            - sh
+            - -c
+            - |
+              PLUGIN_DIR=/config/plugins
+              PLUGIN_FILE="${PLUGIN_DIR}/LdapAuthentication"
+              if [ ! -d "${PLUGIN_FILE}" ]; then
+                mkdir -p "${PLUGIN_DIR}"
+                PLUGIN_VERSION=18
+                curl -fsSL \
+                  "https://repo.jellyfin.org/releases/plugin/ldap-auth/LdapAuthentication_${PLUGIN_VERSION}.zip" \
+                  -o /tmp/ldap-plugin.zip
+                unzip -o /tmp/ldap-plugin.zip -d "${PLUGIN_DIR}/"
+                rm -f /tmp/ldap-plugin.zip
+              fi
+          volumeMounts:
+            - name: config
+              mountPath: /config
+      volumes:
+        - name: ldap-ca
+          secret:
+            items:
+              - key: tls.crt
+                path: ca.crt
+            secretName: openldap-tls

--- a/apps/seerr/overlays/nishir-tailnet/kustomization.yaml
+++ b/apps/seerr/overlays/nishir-tailnet/kustomization.yaml
@@ -3,6 +3,8 @@ resources:
   - netpol.yaml
   - ingress.yaml
 namespace: shikanime
+patches:
+  - path: patch-sts-oidc.yaml
 labels:
   - includeTemplates: true
     pairs:
@@ -11,3 +13,7 @@ labels:
       app.kubernetes.io/name: seerr
       app.kubernetes.io/part-of: nishir-media
       app.kubernetes.io/version: 3.3.0
+secretGenerator:
+  - name: seerr-oidc
+    envs:
+      - oidc.enc.env

--- a/apps/seerr/overlays/nishir-tailnet/oidc.enc.env
+++ b/apps/seerr/overlays/nishir-tailnet/oidc.enc.env
@@ -1,0 +1,12 @@
+OIDC_ENABLED=ENC[AES256_GCM,data:7+ws2Q==,iv:R8Ssyre1s3Dwueifq/G42sEoVqWR/ig9u4BP9jPY0vY=,tag:Z1XobkcmHOCzEj6FkskMOA==,type:str]
+OIDC_CLIENT_ID=ENC[AES256_GCM,data:oLAkRjY=,iv:9ZU4Lvs5WjF9RmylSMKkBfmQIeS3NeKLF7PwxJT84r8=,tag:YykNtBWt2KogTmgHeIKBcQ==,type:str]
+OIDC_CLIENT_SECRET=ENC[AES256_GCM,data:pf2LO44MDZFwplciMymtQLo7dd4fZAv+MKoljGUMzxRCvZILsVgzdlR/kyRjAaDQ7yf0XS/Btco6UwjmqAM35Q==,iv:QQImLbwv7K+VV1rQFKoQnOvyBgRQv1aMmhghp3iiWkg=,tag:BbznnJjD4IGjoYkMelkO0g==,type:str]
+OIDC_AUTHORITY=ENC[AES256_GCM,data:AATfhdg0878hegvOsa9an5DArGX1fgk1Os1ifA==,iv:EiMQbyI/UTnkwnNMyWI6p4WDTWJOouS26SOrXgHN1HY=,tag:FAxBIA1WrqVbUQKmw0EqCw==,type:str]
+OIDC_SCOPES=ENC[AES256_GCM,data:hDMa9+FhwVKl+aLjbe2SfTev7e8=,iv:nU+ksuXpvLyAlOx1iwF30PYQUInm8FLjcGgGis20k/E=,tag:4S++3IpcBkLyprWs0x/yxA==,type:str]
+OIDC_REDIRECT_URL=ENC[AES256_GCM,data:WH/enPkqFEb1WZWn70ebZ2LQTJok74FTe73f5GGUVtwEWDFzUU84CmgOXnl7spC6TmNO,iv:0S4wGzO+awNPlcJDofLNR3Pcx19MMeSoUuzwQu05dbg=,tag:+eWCRQgdhEw28C2QlPjosg==,type:str]
+sops_age__list_0__map_enc=-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBkQlM3YU81cEtDU1dUaHpv\nM3RqZlB0djd3ZzFXNVNDYWliWUxPRVVNR1RJCnYzZW5MeGp3bThsNkVpSWJENjBR\nclY5WGV1MDdXUll3N3c2cEZrbHJWdFEKLS0tIEJrZ0Vtd20rbkFEU2Z6WUZUclAy\nNUdNaURKN0RBV0ZtVWdsTTc4TjY0RlUKVbZ86qVnW58XiXUi9qN2NKLgxjhPbXyd\nKgvP4HEPHZ3dhc+oh2yQe+yQWvZCfDrSoUUDXWBiQ1MmmdtQpdD0Sg==\n-----END AGE ENCRYPTED FILE-----\n
+sops_age__list_0__map_recipient=age139fcg32lmhxupnz5wjex44jur7v7wzf9rttp2grnjmxhukck5dmqsd9zj5
+sops_lastmodified=2026-06-15T18:19:13Z
+sops_mac=ENC[AES256_GCM,data:26XlE+pWz5YxT2ueL8cNLGCuviZyft9lYNTCtDWfJdv+zKr5u8OugH1n7OAx7jQwdGbb96EgGRjKoH54Q/+dLK/1Qo5P3AaeoWL7Ryg9yhHlOoKIh98mIRWTMsX4PX9hweKfcATUAdRGht1P2Ny83asi/XzTetESjD6Muwv0YXo=,iv:aPzF7ZCHO3xgixDuA2u0vloGRwxl7MsKz9UwUkVUYtY=,tag:sOQHDQbss1akmts4ADpsqA==,type:str]
+sops_unencrypted_suffix=_unencrypted
+sops_version=3.13.1

--- a/apps/seerr/overlays/nishir-tailnet/patch-sts-oidc.yaml
+++ b/apps/seerr/overlays/nishir-tailnet/patch-sts-oidc.yaml
@@ -1,0 +1,12 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: seerr
+spec:
+  template:
+    spec:
+      containers:
+        - name: seerr
+          envFrom:
+            - secretRef:
+                name: seerr-oidc

--- a/apps/synapse/overlays/nishir-tailnet/kustomization.yaml
+++ b/apps/synapse/overlays/nishir-tailnet/kustomization.yaml
@@ -2,6 +2,8 @@ resources:
   - ../nishir
   - netpol.yaml
 namespace: shikanime
+patches:
+  - path: patch-sts-oidc.yaml
 labels:
   - includeTemplates: true
     pairs:
@@ -15,3 +17,6 @@ secretGenerator:
     files:
       - homeserver.yaml=synapse/homeserver.enc.yaml
       - synapse/matrix.taila659a.ts.net.log.config
+  - name: synapse-oidc
+    files:
+      - oidc.yaml=synapse/oidc.enc.yaml

--- a/apps/synapse/overlays/nishir-tailnet/patch-sts-oidc.yaml
+++ b/apps/synapse/overlays/nishir-tailnet/patch-sts-oidc.yaml
@@ -1,0 +1,28 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: synapse
+spec:
+  template:
+    spec:
+      initContainers:
+        - name: oidc-config-merge
+          image: busybox:1.37
+          command:
+            - sh
+            - -c
+            - |
+              # Merge OIDC provider config into homeserver.yaml
+              if [ -f /mnt/oidc-config/oidc.yaml ]; then
+                # Append oidc_providers block to homeserver.yaml
+                cat /mnt/oidc-config/oidc.yaml >> /data/homeserver.yaml
+              fi
+          volumeMounts:
+            - name: data
+              mountPath: /data
+            - name: oidc-config
+              mountPath: /mnt/oidc-config
+      volumes:
+        - name: oidc-config
+          secret:
+            secretName: synapse-oidc

--- a/apps/synapse/overlays/nishir-tailnet/synapse/oidc.enc.yaml
+++ b/apps/synapse/overlays/nishir-tailnet/synapse/oidc.enc.yaml
@@ -1,0 +1,30 @@
+oidc_providers:
+  - client_id: ENC[AES256_GCM,data:YjhUQ24W2A==,iv:nVdLAauhJoKetgcW1UeMyY4qGODI/19BjX5PEM26PTI=,tag:x5avrBXe+xHybgWbx/bc7w==,type:str]
+    client_secret: ENC[AES256_GCM,data:h0AvkmT9N8uJg0kEIobInRXaoKqlSenqHpBwppC71gmyiu2QZlQdUgBzfwh5J5mUYhsopdGj/V606vJt2UNURA==,iv:d9cnFSd2WpmlWUE0I59TyNxDL90OaA8ATL37qxJDi68=,tag:BNX3cj0blXKq0+Z/P1rPOg==,type:str]
+    discover: ENC[AES256_GCM,data:xGT/hQ==,iv:mfiIR4k0n1MdFR9R3Y0Ms9uM5jno9mxyGJRrJpWbjJY=,tag:kVbX5vGVLiJpNjVmhpRIwg==,type:bool]
+    idp_id: ENC[AES256_GCM,data:uRTp,iv:dW0uZfUCVfQqLZgA1Kk4zQRM+FT58ONmhn8SlzW0PJ0=,tag:zriXzW0UeABbyYGksznIFA==,type:str]
+    idp_name: ENC[AES256_GCM,data:MNNeB8FP+oo=,iv:ncHYef7Dx2aFRuOWrydWnUjbvgVvX5xd6RyiQPOcatc=,tag:AgkQVmK31KRz6ioUZvP8xg==,type:str]
+    issuer: ENC[AES256_GCM,data:Cz0Ahq2Uo9WEeyiA6f9i6we9qeNxa3HH/kOUNQ==,iv:hr8NjnFD2dGx5kq+MDl6vNUzWbh3NbZK6m9TDJdivus=,tag:ZEaf1XlDzjxyMHBu8g2XDA==,type:str]
+    scopes:
+      - ENC[AES256_GCM,data:OcER4xEz,iv:NI8NMxMU0gipwPVH8EZWbOw5jVFEwotRuxcbcyxifjM=,tag:rBleqXhOMg5p+Ykgxu+llg==,type:str]
+      - ENC[AES256_GCM,data:oB+u8e8UZw==,iv:3avNJDvds5ZQc0kZ9jbAUY67h2k8cUkRBIrh9bNeGgw=,tag:xXF/Hmu1zKHMG6g35bWUAw==,type:str]
+      - ENC[AES256_GCM,data:eUXcI80=,iv:KvwtSsGKK0SQYwZe292qtdM54P6oNHnHsdRgqnUGAU0=,tag:cyEdvRPDfJ5njGWpr8BwrA==,type:str]
+    user_mapping_provider:
+      config:
+        display_name_template: ENC[AES256_GCM,data:2RMfrXvWMaRV3aBIpU/rQe9SOw==,iv:S428Z3UYn7qi9XKN8dV/0TdeEw73cYCEntbPoRYCi0Q=,tag:C50YccQgAjs9hcxqMpNChw==,type:str]
+        localpart_template: ENC[AES256_GCM,data:V32qch/fIkEChkfrfV06zY9/xDIBqFnFfqYdu1Pogk+v,iv:1nfmC34lO4me/v3tDGHnIzGMRvwaI7IsBnaNXcxJabA=,tag:M6zj9uvYoxQGy8vzLXvovA==,type:str]
+sops:
+  version: 3.13.1
+  lastmodified: "2026-06-15T18:19:13Z"
+  mac: ENC[AES256_GCM,data:DysavcRjJiNqF5TGpy5Fc7AG9s+AYCtA3Tyxh/DfyrjGA+w2d85X/8Ux2s/FuiBNcMueovjywBu0DMlfP6Idd3bKlL6Tu9M6YVuAcOxNWcXRCnIMhvfq4SDgkMcHr9bQiNRhlnTLgMxBizeXBwvayWbtjoYViRsjWHaBhdgFlBQ=,iv:rv+8Zk+b1I+vzSK+G14/7EqvHErqzvlWtIVGEatakpU=,tag:sjJSuBVtfrcOZGMS8O58rA==,type:str]
+  unencrypted_suffix: _unencrypted
+  age:
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBmbGpneWZvbFBRVUlLVUNs
+        TWhnbWZYQkNzLzJxRzNCOEcrTTkvcEhmUUdnCkptWjNFTGM0Rm80a1V6azkrY0Jv
+        Q0VkRHNONUNlMWM0TDMrcGdhZkZWOVUKLS0tICtDSjUySmZSVmFjTDBQR0Y5RzFN
+        d0RtZER5YjR5bTZTbWlkanpkUUM2dXMKE1/7YtC+aK9nSnb0Vl1qDyBoxQPoHfSa
+        FGWTYWO1x5XzK+MJsJpZPFydDiNp8X1Cy9dIU+HrtDH36xENn29U3Q==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age139fcg32lmhxupnz5wjex44jur7v7wzf9rttp2grnjmxhukck5dmqsd9zj5

--- a/apps/vaultwarden/overlays/nishir-tailnet/kustomization.yaml
+++ b/apps/vaultwarden/overlays/nishir-tailnet/kustomization.yaml
@@ -3,6 +3,8 @@ resources:
   - netpol.yaml
   - ingress.yaml
 namespace: shikanime
+patches:
+  - path: patch-sts-sso.yaml
 labels:
   - includeTemplates: true
     pairs:
@@ -11,3 +13,7 @@ labels:
       app.kubernetes.io/name: vaultwarden
       app.kubernetes.io/part-of: nishir-security
       app.kubernetes.io/version: 1.36.0
+secretGenerator:
+  - name: vaultwarden-sso
+    envs:
+      - vaultwarden/sso.enc.env

--- a/apps/vaultwarden/overlays/nishir-tailnet/patch-sts-sso.yaml
+++ b/apps/vaultwarden/overlays/nishir-tailnet/patch-sts-sso.yaml
@@ -1,0 +1,16 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: vaultwarden
+spec:
+  template:
+    spec:
+      containers:
+        - name: vaultwarden
+          envFrom:
+            - secretRef:
+                name: vaultwarden-sso
+      volumes:
+        - name: sso-config
+          secret:
+            secretName: vaultwarden-sso

--- a/apps/vaultwarden/overlays/nishir-tailnet/vaultwarden/sso.enc.env
+++ b/apps/vaultwarden/overlays/nishir-tailnet/vaultwarden/sso.enc.env
@@ -1,0 +1,12 @@
+SSO_ENABLED=ENC[AES256_GCM,data:vejvQQ==,iv:HJNigspJ6b6y5YgpgrF82Ovw/PSCzYkThUG/QvxfQ40=,tag:y8WrLs405VQVjB27QYW6FQ==,type:str]
+SSO_CLIENT_ID=ENC[AES256_GCM,data:vvvgYTFNLltkVoA=,iv:aQsIehs6IGyXaNPv7sANSV0cPKxOtLbo3ADydPF+rfM=,tag:colDl/rBUZ6mw/A1vOJ6Ng==,type:str]
+SSO_CLIENT_SECRET=ENC[AES256_GCM,data:4qTrbKsKPPFyuTj8CvRd3WMGMCyB7P9HAkwKtWJ5UE8Zql3rtfz6vSimJ2R7MHFmXjsx2hvZeB7rkAoTgAm59g==,iv:7o66fm8JjAzNvZ2IM5ilEyDMpTQJ42YPCyJM3+ScDIc=,tag:I8ohBTf+L7EM1CRNzJszpg==,type:str]
+SSO_AUTHORITY=ENC[AES256_GCM,data:SDBlbwisITrmA021yNsLu6gU6xBnB6388ViDcQ==,iv:3HjmTJVC5itHfUuHXhk24lojHV6CNkao92yolQf7zws=,tag:zwgcqEo8Rdp6biq3XxW3rg==,type:str]
+SSO_SCOPES=ENC[AES256_GCM,data:K9HT7CCRTDs/EbPEosvdjW48lf0=,iv:wJHZ/TH55EXILWmsCicZHm1TEGFmrGR6Eim70lg5K9w=,tag:mNzMjRk9gfUKtl4oTx86RA==,type:str]
+SSO_REDIRECT_URL=ENC[AES256_GCM,data:auUhdPqRqN8ZsJ51gGqlz635WaRvOpGIKIBSFzOeSF5cuN8/ElpMUXUewyiuheRsyj0kpwuSJdxZxE4W3wOhscek+w==,iv:y6HxGTedS28twhWLhMr08ye41NsT+s931GlB4H5t+y8=,tag:pSs4azjhHjCAT/k9J/Yffg==,type:str]
+sops_age__list_0__map_enc=-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBzSU95dnErbXpYRi9QdjAr\ndzZmV210YmhJQWNYaXNDb1ZQNkJMaXBvRUNJCjlBYkV6MHkwYlR3dTJwT3A0UHdp\nZlM0SDlSU1dRVjZPVnpnMU1PWG1icmMKLS0tIEQ2ZW8yWENsTTVnS1VHcGhoeWlK\nQ2FnU1RNWDlYNlZLanQ2K3VFdzRLOHMKNuEgDBYK61i9/Z2iAj8ok0SWGus8AsxE\nRy22zQzCuhSR+UowoAiQAT+nvl1kzFVEzpNDys/L9pubYevGvsUv8Q==\n-----END AGE ENCRYPTED FILE-----\n
+sops_age__list_0__map_recipient=age139fcg32lmhxupnz5wjex44jur7v7wzf9rttp2grnjmxhukck5dmqsd9zj5
+sops_lastmodified=2026-06-15T18:19:13Z
+sops_mac=ENC[AES256_GCM,data:1TmxafAWMUJz4n6h8rN1cSI2BRKjeNBlvoSnaegZ4htOd2Wn+qjZF3ES56YNMcxfU19obo5q2N3A5EFpyq2wxRc4Y2fq08LzsxIKGyfRXme8OyzWtKuz24gHnRBpGIijyLxDFL3+lzRFfdJN4KQrzNe5mNI9CBOOcuq5b2d7NeQ=,iv:azMICB8GZda0mfVXzwGUJDZTkfYlMpQuE7gYCtqSqxo=,tag:IJ2yWf5ONvcNp8CpowDbSA==,type:str]
+sops_unencrypted_suffix=_unencrypted
+sops_version=3.13.1


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* __->__ #1670
* #1669

Wire copyparty, forgejo, gitea-mirror, jellyfin, seerr, synapse, and
vaultwarden to the shared SSO identity provider via sops-encrypted
secrets and init-container patches.

Signed-off-by: William Phetsinorath <william.phetsinorath@shikanime.studio>