### PR TITLE
Fix Syncthing missing netpol

### DIFF
--- a/apps/syncthing/overlays/nishir/kustomization.yaml
+++ b/apps/syncthing/overlays/nishir/kustomization.yaml
@@ -2,7 +2,6 @@ resources:
   - ../../base
   - backendtlspolicy.yaml
   - cert.yaml
-  - netpol.yaml
 namespace: shikanime
 components:
   - ../../components/tls


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* __->__ #1676

Signed-off-by: Shikanime Deva <william.phetsinorath@shikanime.studio>
Change-Id: I6d3b883448d43073f9908793014f5fb46a6a6964