### PR TITLE
Missing VictoriaMetrics ServiceMonitor CRD

### DIFF
--- a/infrastructure/monitoring/base/hr.yaml
+++ b/infrastructure/monitoring/base/hr.yaml
@@ -27,6 +27,8 @@ spec:
         size: 2Gi
     kubeProxy:
       enabled: true
+    serviceMonitor:
+      enabled: true
     vmalert:
       extraArgs:
         enableTCP6: "true"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* __->__ #1683

Signed-off-by: Shikanime Deva <william.phetsinorath@shikanime.studio>
Change-Id: I0c6a130f4991fd23035b8ba1273aeb2c6a6a6964