### PR TITLE
Remove master interface from nad

### DIFF
--- a/infrastructure/longhorn/overlays/nishir/netattachdef.yaml
+++ b/infrastructure/longhorn/overlays/nishir/netattachdef.yaml
@@ -9,7 +9,6 @@ spec:
       "cniVersion": "0.4.0",
       "name": "longhorn-storage",
       "type": "macvlan",
-      "master": "enp1s0",
       "ipam": {
         "request": [
           { "skipDefault": true },


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* __->__ #1693

Signed-off-by: Shikanime Deva <william.phetsinorath@shikanime.studio>
Change-Id: I6d12a7fd28ce8e81ac25c1e48c48afd66a6a6964