### PR TITLE
Return Gatekeeper replicas to 3 by default

### DIFF
--- a/infrastructure/gatekeeper/base/hr.yaml
+++ b/infrastructure/gatekeeper/base/hr.yaml
@@ -34,6 +34,5 @@ spec:
     pdb:
       controllerManager:
         minAvailable: 1
-    replicas: 2
     upgradeCRDs:
       enabled: false


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* __->__ #1695

Signed-off-by: Shikanime Deva <william.phetsinorath@shikanime.studio>
Change-Id: I0d4a1755c54b60c50326610f5a0881cc6a6a6964