### PR TITLE
Add default Tailscale ProxyClass to avoid RPI workloads

### DIFF
--- a/infrastructure/tailscale/overlays/nishir/kustomization.yaml
+++ b/infrastructure/tailscale/overlays/nishir/kustomization.yaml
@@ -1,5 +1,6 @@
 resources:
   - ../../base
+  - proxyclass.yaml
 patches:
   - path: patch-hr.yaml
 secretGenerator:

--- a/infrastructure/tailscale/overlays/nishir/patch-hr.yaml
+++ b/infrastructure/tailscale/overlays/nishir/patch-hr.yaml
@@ -7,3 +7,5 @@ spec:
   values:
     operatorConfig:
       hostname: nishir-k8s-operator
+    proxyConfig:
+      defaultProxyClass: nishir

--- a/infrastructure/tailscale/overlays/nishir/proxyclass.yaml
+++ b/infrastructure/tailscale/overlays/nishir/proxyclass.yaml
@@ -1,0 +1,18 @@
+apiVersion: tailscale.com/v1alpha1
+kind: ProxyClass
+metadata:
+  name: nishir
+spec:
+  statefulSet:
+    pod:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - preference:
+                matchExpressions:
+                  - key: node.kubernetes.io/instance-type
+                    operator: NotIn
+                    values:
+                      - rpi4-model-b
+                      - rpi5
+              weight: 100


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* #1701
* #1700
* __->__ #1699

Signed-off-by: Shikanime Deva <william.phetsinorath@shikanime.studio>
Change-Id: I68f09addc3950a3ea4d56309a29648fd6a6a6964