### PR TITLE
Fix NFD PodSecurity enforcement

### DIFF
--- a/infrastructure/node-feature-discovery/base/ns.yaml
+++ b/infrastructure/node-feature-discovery/base/ns.yaml
@@ -2,3 +2,10 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: node-feature-discovery-system
+  labels:
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/enforce-version: latest
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/audit-version: latest
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/warn-version: latest

--- a/infrastructure/node-feature-discovery/components/monitoring/vmservicescrape.yaml
+++ b/infrastructure/node-feature-discovery/components/monitoring/vmservicescrape.yaml
@@ -14,7 +14,7 @@ spec:
       scrapeTimeout: 30s
   namespaceSelector:
     matchNames:
-      - node-feature-discovery
+      - node-feature-discovery-system
   selector:
     matchLabels:
       app.kubernetes.io/component: worker


### PR DESCRIPTION
Allow baseline hostPath volumes for node-feature-discovery worker DaemonSet.

Related: nishir infrastructure