### PR TITLE
Fix NFR cpu.vendor_id reference

### DIFF
--- a/configs/node-feature-discovery/nfr.yaml
+++ b/configs/node-feature-discovery/nfr.yaml
@@ -9,12 +9,6 @@ spec:
       labels:
         qsv.enabled: "true"
       matchFeatures:
-        - feature: cpu.vendor_id
-          matchExpressions:
-            value:
-              op: In
-              value:
-                - GenuineIntel
         - feature: pci.class
           matchExpressions:
             value:
@@ -23,14 +17,8 @@ spec:
                 - "0300"
     - name: qsv.device
       labels:
-        qsv.device: "{{ .domain }}.{{ .feature }}"
+        qsv.device: '{{ .domain }}.{{ .feature }}'
       matchFeatures:
-        - feature: cpu.vendor_id
-          matchExpressions:
-            value:
-              op: In
-              value:
-                - GenuineIntel
         - feature: pci.class
           matchExpressions:
             value:

--- a/infrastructure/node-feature-discovery/base/hr.yaml
+++ b/infrastructure/node-feature-discovery/base/hr.yaml
@@ -17,7 +17,11 @@ spec:
   releaseName: node-feature-discovery
   targetNamespace: node-feature-discovery-system
   values:
+    featureGates:
+      NodeFeatureGroupAPI: true
     master:
+      extraArgs:
+        - -feature-gates=NodeFeatureGroupAPI=true
       replicaCount: 1
     worker:
       config:


### PR DESCRIPTION
NFD v0.18.0 stores CPU under cpuid flags, not vendor_id. Match on PCI class only for Intel GPU detection.

Signed-off-by: Operator 21O <operator21O@shikanime.labs>