### PR TITLE
Fix copyparty IdP authentication by disabling basic auth

### DIFF
--- a/apps/copyparty/overlays/nishir-tailnet/copyparty/config.conf
+++ b/apps/copyparty/overlays/nishir-tailnet/copyparty/config.conf
@@ -18,6 +18,7 @@
   ah-alg: argon2
   dav-auth
   idp-h-usr: Tailscale-User-Login
+  no-bauth
 
   # Reverse Proxy
   # For the Tailscale Ingress IdP header (Tailscale-User-Login) to be trusted

--- a/apps/synapse/base/pvc.yaml
+++ b/apps/synapse/base/pvc.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   resources:
     requests:
-      storage: 32Gi
+      storage: 64Gi
   volumeMode: Filesystem
   accessModes:
     - ReadWriteOncePod


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* __->__ #1714

The copyparty IdP authentication was not working because basic auth was
still being accepted. By adding 'no-bauth' to the config, we force
authentication to use only the Tailscale-User-Login header provided by
the Tailscale ingress.

This ensures that the IdP header is properly used for authentication
instead of falling back to basic auth or accepting both methods.

Signed-off-by: Shikanime Deva <shikanime.deva@gmail.com>
Signed-off-by: Shikanime Deva <william.phetsinorath@shikanime.studio>