### PR TITLE
Mount Hermes Agent PVC read-only in Syncthing

### DIFF
--- a/apps/syncthing/overlays/nishir/patch-sts.yaml
+++ b/apps/syncthing/overlays/nishir/patch-sts.yaml
@@ -34,6 +34,9 @@ spec:
               mountPath: /var/syncthing/Sync
             - name: timeline-data
               mountPath: /var/syncthing/Timeline
+            - name: hermes-agent-data
+              mountPath: /var/syncthing/Hermes
+              readOnly: true
       volumes:
         - name: archives-data
           persistentVolumeClaim:
@@ -74,3 +77,6 @@ spec:
         - name: timeline-data
           persistentVolumeClaim:
             claimName: timeline-data
+        - name: hermes-agent-data
+          persistentVolumeClaim:
+            claimName: hermes-agent-data


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* __->__ #1716

Hermes data is a sync source, not a write target, so read-only mount
resolves the fsGroup mismatch (Syncthing 1000 vs Hermes 10000)
without changing PodSecurityContext.

Change-Id: I961268988be47de27d235944580b15d73fb63b55
Signed-off-by: Shikanime Deva <william.phetsinorath@shikanime.studio>