### PR TITLE
Add granular workload affinity rules for Jellyfin and Metatube

### DIFF
--- a/apps/forgejo/overlays/nishir/kustomization.yaml
+++ b/apps/forgejo/overlays/nishir/kustomization.yaml
@@ -7,3 +7,4 @@ components:
   - ../../components/tls
 patches:
   - path: patch-pvc.yaml
+  - path: patch-sts.yaml

--- a/apps/forgejo/overlays/nishir/patch-sts.yaml
+++ b/apps/forgejo/overlays/nishir/patch-sts.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: qbittorrent
+  name: forgejo
 spec:
   template:
     spec:
@@ -15,12 +15,3 @@ spec:
                     values:
                       - "true"
               weight: 50
-      containers:
-        - name: qbittorrent
-          volumeMounts:
-            - name: downloads-data
-              mountPath: /downloads
-      volumes:
-        - name: downloads-data
-          persistentVolumeClaim:
-            claimName: downloads-data

--- a/apps/synapse/overlays/nishir/patch-sts.yaml
+++ b/apps/synapse/overlays/nishir/patch-sts.yaml
@@ -5,6 +5,16 @@ metadata:
 spec:
   template:
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - preference:
+                matchExpressions:
+                  - key: network.speed.2.5g
+                    operator: In
+                    values:
+                      - "true"
+              weight: 50
       containers:
         - name: synapse
           livenessProbe:

--- a/apps/syncthing/overlays/nishir/patch-sts.yaml
+++ b/apps/syncthing/overlays/nishir/patch-sts.yaml
@@ -5,6 +5,16 @@ metadata:
 spec:
   template:
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - preference:
+                matchExpressions:
+                  - key: network.speed.2.5g
+                    operator: In
+                    values:
+                      - "true"
+              weight: 50
       containers:
         - name: syncthing
           volumeMounts:

--- a/configs/gatekeeper/overlays/nishir/mutations.yaml
+++ b/configs/gatekeeper/overlays/nishir/mutations.yaml
@@ -2,45 +2,6 @@
 apiVersion: mutations.gatekeeper.sh/v1
 kind: Assign
 metadata:
-  name: set-pod-soft-anti-affinity-rpi
-spec:
-  applyTo:
-    - groups:
-        - ""
-      kinds:
-        - Pod
-      versions:
-        - v1
-  location: spec.affinity
-  match:
-    kinds:
-      - apiGroups:
-          - ""
-        kinds:
-          - Pod
-    namespaces:
-      - shikanime
-    scope: Namespaced
-  parameters:
-    assign:
-      value:
-        nodeAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-            - preference:
-                matchExpressions:
-                  - key: node.kubernetes.io/instance-type
-                    operator: NotIn
-                    values:
-                      - rpi4-model-b
-                      - rpi5
-              weight: 100
-    pathTests:
-      - condition: MustNotExist
-        subPath: spec.affinity
----
-apiVersion: mutations.gatekeeper.sh/v1
-kind: Assign
-metadata:
   name: set-pod-nishir-ca-certificates-volume
 spec:
   applyTo:


### PR DESCRIPTION
Replace broad RPI affinity avoidance with workload-specific rules:
- Jellyfin: add hard workload-capacity.high node selector alongside existing qsv.enabled hard requirement and network.speed.2.5g soft preference (weight 50)
- Metatube: add soft network.speed.2.5g preference (weight 10) for low-resource co-location with servarr/bazarr
- NodeFeatureDiscovery: add workload-capacity.high label rule (igc/r8125 2.5GbE kernel modules) to support Jellyfin hard requirement

Design: docs/affinity-rules-design.md