### PR TITLE
fix(descheduler): add CreateContainerError to PodLifeTime.states

### DIFF
--- a/infrastructure/descheduler/base/hr.yaml
+++ b/infrastructure/descheduler/base/hr.yaml
@@ -44,6 +44,7 @@ spec:
                 states:
                   - Pending
                   - PodInitializing
+                  - CreateContainerError
             - name: RemoveFailedPods
               args:
                 includingInitContainers: true


### PR DESCRIPTION
## Bug

The descheduler is not cleaning up pods stuck in CreateContainerError. When a pod's container fails to create (e.g. due to missing image, bad command, or resource constraints), it remains in the Pending phase with Status.Reason=CreateContainerError indefinitely.

## Root Cause

The descheduler has two relevant plugins:

- **RemoveFailedPods**: Only acts on pods where . Pods with CreateContainerError remain in the Pending phase, so RemoveFailedPods cannot evict them — even though CreateContainerError is already listed in its  filter, that filter is never reached because the phase check fails first.
- **PodLifeTime**: Evicts pods matching configured  (which maps to ). This plugin already lists CreateContainerError in RemoveFailedPods.reasons, but PodLifeTime only checks states by phase, and Pending is already handled generically via maxPodLifeTimeSeconds.

The core gap: there is no descheduler plugin that evicts Pending-phase pods specifically when their Status.Reason is CreateContainerError.

## Fix

Added  to the  list in the descheduler HelmRelease values. The upstream descheduler (kubernetes-sigs/descheduler v0.36.0) PodLifeTime plugin checks both  and  when matching states. Adding CreateContainerError as a state ensures Pending-phase pods with this specific reason are matched and evicted.

This complements the existing RemoveFailedPods configuration (which already lists CreateContainerError in reasons but cannot act on Pending-phase pods).

## Changes

- : Added  to 

## Verification

- YAML parsed successfully with Python yaml.safe_load
- Upstream descheduler 0.36.0 source confirmed PodLifeTime matches both PodPhase and PodStatus.Reason
- No overlays override the base PodLifeTime states list