### PR TITLE
Allow kube-dns VIP egress from synapse-proxy

### DIFF
--- a/apps/synapse-proxy/base/sts.yaml
+++ b/apps/synapse-proxy/base/sts.yaml
@@ -15,6 +15,22 @@ spec:
         app.kubernetes.io/instance: synapse-proxy
         app.kubernetes.io/name: synapse-proxy
     spec:
+      # Dual-stack cluster but the IPv6 kube-dns VIP (fd01::a) is unreachable
+      # under canal/flannel host-gw + ipvs, and Go's resolver round-robins onto
+      # it -> 502s. Pin the IPv4 VIP (allowed by the netpol ipBlock) and drop
+      # the dead IPv6 entry. Removable once knix drops the IPv6 service CIDR.
+      dnsPolicy: None
+      dnsConfig:
+        nameservers:
+          - 10.96.0.10
+        searches:
+          - shikanime.svc.cluster.local
+          - svc.cluster.local
+          - cluster.local
+          - taila659a.ts.net
+        options:
+          - name: ndots
+            value: "5"
       affinity:
         podAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:

--- a/apps/synapse-proxy/overlays/nishir-tailnet/ingress.yaml
+++ b/apps/synapse-proxy/overlays/nishir-tailnet/ingress.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     tailscale.com/funnel: "true"
     tailscale.com/tags: tag:web
+    tailscale.com/proxy-class: nishir
 spec:
   defaultBackend:
     service:

--- a/apps/synapse-proxy/overlays/nishir-tailnet/netpol.yaml
+++ b/apps/synapse-proxy/overlays/nishir-tailnet/netpol.yaml
@@ -25,6 +25,10 @@ spec:
         - namespaceSelector:
             matchLabels:
               kubernetes.io/metadata.name: kube-system
+        # kube-dns Service VIP is virtual (no backing pod), so Canal cannot
+        # match it via the namespaceSelector above. Allow it explicitly.
+        - ipBlock:
+            cidr: 10.96.0.10/32
   ingress:
     - from:
         - namespaceSelector:

--- a/configs/tailscale/overlays/nishir/proxyclass.yaml
+++ b/configs/tailscale/overlays/nishir/proxyclass.yaml
@@ -5,6 +5,22 @@ metadata:
 spec:
   statefulSet:
     pod:
+      # Dual-stack cluster but the IPv6 kube-dns VIP (fd01::a) is unreachable
+      # under canal/flannel host-gw + ipvs, and Go's resolver round-robins onto
+      # it -> 502s. Pin the IPv4 VIP (allowed by the netpol ipBlock) and drop
+      # the dead IPv6 entry. Removable once knix drops the IPv6 service CIDR.
+      dnsPolicy: None
+      dnsConfig:
+        nameservers:
+          - 10.96.0.10
+        searches:
+          - tailscale-system.svc.cluster.local
+          - svc.cluster.local
+          - cluster.local
+          - taila659a.ts.net
+        options:
+          - name: ndots
+            value: "5"
       affinity:
         nodeAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* __->__ #1725

NetworkPolicy egress was deny-by-default and only permitted DNS to
kube-system pods. The kube-dns Service VIP (10.96.0.10) is virtual
(no backing pod) so Canal could not match it and dropped all VIP DNS,
causing 502s on every Matrix request. Add an ipBlock for the VIP and
pin the IPv4 nameserver in the proxy pods (the dual-stack IPv6 VIP
fd01::a is unreachable under canal host-gw + ipvs).

Design: Tailscale proxy-class annotation also added so ts-matrix routes
through the cluster proxy.
Related: knix dual-stack service-cidr

Signed-off-by: Shikanime Deva <william.phetsinorath@shikanime.studio>
Change-Id: I569c14b43a281b71f021d4601edd90896a6a6964