### PR TITLE
Bump mautrix image tags to v0.2607.0

### DIFF
--- a/apps/mautrix/meta/base/kustomization.yaml
+++ b/apps/mautrix/meta/base/kustomization.yaml
@@ -6,7 +6,7 @@ resources:
 images:
   - name: mautrix
     newName: dock.mau.dev/mautrix/meta
-    newTag: v0.2605.1
+    newTag: v0.2607.0
   - name: rclone
     newName: rclone/rclone
     newTag: 1.74.4
@@ -28,4 +28,4 @@ labels:
       app.kubernetes.io/instance: mautrix-meta
       app.kubernetes.io/name: mautrix-meta
       app.kubernetes.io/part-of: nishir-office
-      app.kubernetes.io/version: 0.2605.1
+      app.kubernetes.io/version: 0.2607.0

--- a/apps/mautrix/signal/base/kustomization.yaml
+++ b/apps/mautrix/signal/base/kustomization.yaml
@@ -6,7 +6,7 @@ resources:
 images:
   - name: mautrix
     newName: dock.mau.dev/mautrix/signal
-    newTag: v0.2605.0
+    newTag: v0.2607.0
   - name: rclone
     newName: rclone/rclone
     newTag: 1.74.4
@@ -28,4 +28,4 @@ labels:
       app.kubernetes.io/instance: mautrix-signal
       app.kubernetes.io/name: mautrix-signal
       app.kubernetes.io/part-of: nishir-office
-      app.kubernetes.io/version: 0.2605.0
+      app.kubernetes.io/version: 0.2607.0

--- a/apps/mautrix/slack/base/kustomization.yaml
+++ b/apps/mautrix/slack/base/kustomization.yaml
@@ -6,7 +6,7 @@ resources:
 images:
   - name: mautrix
     newName: dock.mau.dev/mautrix/slack
-    newTag: v0.2605.0
+    newTag: v0.2607.0
   - name: rclone
     newName: rclone/rclone
     newTag: 1.74.4
@@ -28,4 +28,4 @@ labels:
       app.kubernetes.io/instance: mautrix-slack
       app.kubernetes.io/name: mautrix-slack
       app.kubernetes.io/part-of: nishir-office
-      app.kubernetes.io/version: 0.2605.0
+      app.kubernetes.io/version: 0.2607.0

--- a/apps/mautrix/whatsapp/base/kustomization.yaml
+++ b/apps/mautrix/whatsapp/base/kustomization.yaml
@@ -6,7 +6,7 @@ resources:
 images:
   - name: mautrix
     newName: dock.mau.dev/mautrix/whatsapp
-    newTag: v0.2605.0
+    newTag: v0.2607.0
   - name: rclone
     newName: rclone/rclone
     newTag: 1.74.4
@@ -28,4 +28,4 @@ labels:
       app.kubernetes.io/instance: mautrix-whatsapp
       app.kubernetes.io/name: mautrix-whatsapp
       app.kubernetes.io/part-of: nishir-office
-      app.kubernetes.io/version: 0.2605.0
+      app.kubernetes.io/version: 0.2607.0


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* __->__ #1726

July 2026 mautrix release. Update whatsapp, signal, slack, and meta bridges
from the v0.2605.x series to v0.2607.0. Rclone image unchanged.

Design: mautrix July 2026 release (https://mau.fi/blog/2026-07-mautrix-release/)
Related: t_a90e8200 (image research)
Signed-off-by: Shikanime Deva <william.phetsinorath@shikanime.studio>