### PR TITLE
Wire Synapse OIDC through Dex

### DIFF
--- a/.sops.yaml
+++ b/.sops.yaml
@@ -1,0 +1,13 @@
+creation_rules:
+  - age:
+      age17q5ljstyzkvqtejwfnyf5jvqduars2yauw7vtgu5fcf54tm2jf0sspvt3c,
+      age1x9v4ps90txy9mk4392uya93tyzx40te4dvns4chg5s6q8mfy03ns74jpay,
+      age1f4yuh4j3gqafjduusfpxz3na9xtwth9s6gznq043mfex0zglp5jqkkdm64
+    encrypted_regex: secret$
+    path_regex: apps/dex/overlays/.*/dex/config\.enc\.yaml
+  - age:
+      age17q5ljstyzkvqtejwfnyf5jvqduars2yauw7vtgu5fcf54tm2jf0sspvt3c,
+      age1x9v4ps90txy9mk4392uya93tyzx40te4dvns4chg5s6q8mfy03ns74jpay,
+      age1f4yuh4j3gqafjduusfpxz3na9xtwth9s6gznq043mfex0zglp5jqkkdm64
+    encrypted_regex: (registration_shared_secret|form_secret|macaroon_secret_key|client_secret)$
+    path_regex: apps/synapse/overlays/.*/synapse/homeserver\.enc\.yaml

--- a/apps/dex/overlays/nishir-tailnet/dex/config.enc.yaml
+++ b/apps/dex/overlays/nishir-tailnet/dex/config.enc.yaml
@@ -1,68 +1,68 @@
 issuer: https://accounts.taila659a.ts.net
 oauth2:
-  skipApprovalScreen: true
-sops:
-  version: 3.13.3
-  encrypted_regex: secret$
-  lastmodified: "2026-08-09T01:19:39Z"
-  mac: ENC[AES256_GCM,data:SUO+Vb9Todce5TWv5RjOJiqIVo18WratIiprEXW01I36xYoQLY6lB8T+ma0VeA8zuFxJekSAK895L+0kKUuzcQuonnDLZbdHN/W7raIO79fVdPFata32HAOtW99GDmMHTJ0uR1WhY7aVTr30vi2x7EWqdKQpjL3GaQ6ozfmK3UI=,iv:xO5aCNQGthpFWnViuQ28W9AdjFbuXyJ2WdJ3sskEFzg=,tag:XT2bRIkVB4cVmQL8/hVcIg==,type:str]
-  age:
-    - enc: |
-        -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBia2s2RVl5QURLRnJ2bjUz
-        cGwxUkZyaDdwV0ptb1BxSkUxNTI5VnBhL1c4ClBRck5nOFluYU1xb2tkeGdkRVo2
-        REh0c1RCQmFHN2JqZmJRdEg5cHRoSDQKLS0tIC9Ienc1VzhaalRlckpDdVFOdGNK
-        Ylc4MXorTVptMURENm9pR3BHdERUWkEKGxbQxQtoyB1V9cp0/XQKB7p+sAcumZHU
-        dM/caSUynt7gJU4pbxsxDETkN+7VDZylvs1uean0HSIk1AzzLecc2w==
-        -----END AGE ENCRYPTED FILE-----
-      recipient: age17q5ljstyzkvqtejwfnyf5jvqduars2yauw7vtgu5fcf54tm2jf0sspvt3c
-    - enc: |
-        -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBGS2c2VTZ6YTBUUXBCQUp5
-        SENqOEFrRFpabGxOalRodlJoT2FocGFNTEhVCm9CU1RmSnpUL0t6NFQ3Y2R2V1lF
-        SHdobVFxemg3RnJEWTV2MVU5TVJvOGcKLS0tIHRKUXdGLzFkTGFwVEZJc1pHd2lO
-        WWsxVERDYTVONzlxWi9GVmE3dDNxY0EKIRoA4YAOYRLuRbqYyw+GIs0Kbu1uImnd
-        SZ31PYwhEIfTQJjJV9YhOPW0uwnA65FtxZ1gblHRhT7/JvUQBppK2w==
-        -----END AGE ENCRYPTED FILE-----
-      recipient: age1x9v4ps90txy9mk4392uya93tyzx40te4dvns4chg5s6q8mfy03ns74jpay
-    - enc: |
-        -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBJYkZady9ZUjFRcWNJNEor
-        U0dsenMwc3BMdTBpazErUHVicHVGQ2I3YW1vCjRJeUltT1lZczNsWVlxdjNWeUhE
-        TkVCemo5VExBWHRCUTNPbnhveGU2Q2cKLS0tIE0vRjRSWWsvSVpjTUZhcFVQZytH
-        dWZ5RmE2clN5VVk3R3hWN2UzV1hxWFEKeFfd1SyGaTs81aSrBm077Hcu4P5ri4vH
-        DZNAYZZWJ0JdXll/PsBn0sKaWSwelMCMag68v3zRS2MAHaXqp0B7AA==
-        -----END AGE ENCRYPTED FILE-----
-      recipient: age1f4yuh4j3gqafjduusfpxz3na9xtwth9s6gznq043mfex0zglp5jqkkdm64
+    skipApprovalScreen: true
 staticClients:
-  - name: Forgejo
-    id: forgejo
-    secret: ENC[AES256_GCM,data:S5Ib3wzhGeWmJa/keu+QjsJy6eNmxjcgQu6l8U6ubJ7hBuFg3JKbHw5cwQo0sObFSRM74Mo/ynhrx46vZCAh0w==,iv:M742SILJtp2lajyolrkousBved3L8nNVQ4DNZGpAu74=,tag:/RLDNVRcbZJjeH3kReioJQ==,type:str]
-    redirectURIs:
-      - https://forgejo.taila659a.ts.net/user/oauth2/Dex/callback
-    trustedPeers:
-      - "*"
-  - name: Gitea Mirror
-    id: gitea-mirror
-    secret: ENC[AES256_GCM,data:iOSWa8jsS6X8ZuDycXpVMuhqFipnLDecIZ6H49kzIAATgREhbXTS2g6J+rg0zC04ZGUxnyHVHP/5LZGT+5LXsA==,iv:UgY+dzGY2aPmyrfh8WlP4M7GlUWX5+3+xzevSc+qcQA=,tag:cszFCXYR01yXkv0PKxoJHw==,type:str]
-    redirectURIs:
-      - https://gitea-mirror.taila659a.ts.net/api/auth/sso/callback/dex
-    trustedPeers:
-      - "*"
-  - name: Synapse
-    id: synapse
-    secret: ENC[AES256_GCM,data:YZvsTsnePc1f6n5395Y83nt1LYyPJP/VnPjPNVj+gRBSTLw16Jorhqj5sWb/HNdzMNawJC7gAesDkxxEU74VBQ==,iv:1ialxMgFMHPWxoPOOY2sCc0jE5xbuyBAKzPfofqXOnw=,tag:X3O76uhpszNscO0sapezBw==,type:str]
-    redirectURIs:
-      - https://matrix.taila659a.ts.net/_matrix/oidc/callback/synapse
-    trustedPeers:
-      - "*"
+    - name: Forgejo
+      id: forgejo
+      secret: ENC[AES256_GCM,data:c5Nnq9ZZdxLHXd9/9yLRDllxuW78xt14uhk18afppdJv3nppU72CSQWgQ8zkoZBYzVoQeMIHMAIT2UtXVM4zDQ==,iv:uIC3oSjfO8ICN81IURornHwdiiHogl0zceQNj0uPVek=,tag:KYoPTERa1Em+YrY063Q7SQ==,type:str]
+      redirectURIs:
+        - https://forgejo.taila659a.ts.net/user/oauth2/Dex/callback
+      trustedPeers:
+        - '*'
+    - name: Gitea Mirror
+      id: gitea-mirror
+      secret: ENC[AES256_GCM,data:Y8DwJm5oJUC44dWU3spcIuzH4YUtNO5iRH91tPfAqSbgtGL3x5IU2Nd+Q4iQbK+2fOBRjydw1xQT//0q+rOMQQ==,iv://YqsEaJX1Gen2vjCWEesadI3BogLAPm3UkW5LukMGA=,tag:4dYeFCkXyl88hjNVvvLhLg==,type:str]
+      redirectURIs:
+        - https://gitea-mirror.taila659a.ts.net/api/auth/sso/callback/dex
+      trustedPeers:
+        - '*'
+    - name: Synapse
+      id: synapse
+      secret: ENC[AES256_GCM,data:oPaWuChLbupeOSGy9YF989HHW10Vj/PjxMVDOVhoaEdtv9kaQmfGn4rhsTQhDA2z443GJGte/nm1loQsTv5LCQ==,iv:nsgAQ54krWFTFCSzg6cycyOm0IdS3etf9P2GgRIS9DE=,tag:kH5VPgL7XoVJwxTmFp8gBQ==,type:str]
+      redirectURIs:
+        - https://matrix.taila659a.ts.net/_matrix/oidc/callback/synapse
+      trustedPeers:
+        - '*'
 storage:
-  type: memory
+    type: memory
 telemetry:
-  http: 0.0.0.0:5558
+    http: 0.0.0.0:5558
 web:
-  gracefulShutdownTimeout: 5s
-  healthz: 0.0.0.0:5556
-  https: 0.0.0.0:5556
-  tlsCert: /etc/ssl/private/tls.crt
-  tlsKey: /etc/ssl/private/tls.key
+    gracefulShutdownTimeout: 5s
+    healthz: 0.0.0.0:5556
+    https: 0.0.0.0:5556
+    tlsCert: /etc/ssl/private/tls.crt
+    tlsKey: /etc/ssl/private/tls.key
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBibjJlYnplaXpjUTlPTmYx
+            TUNWbXg4NGtkNW1MQnh1ZTNzOW1OK1RTR0FNCmJWcXNKZ0lvUzI0S05tTytGY3d0
+            TnV1Q215WTcvdncwa0RQMC9KdzFWTkUKLS0tIFNQbHFkSnR1MkJGK28yU1Y4cXNa
+            YnpzODBhb3dQMkFrMk9ELytobktTTDAK7U3AEnNA3ONQy7i8V/2h33AmmFg+NSUe
+            VGYZOHCxfLziHguG/VDEJAdDkjfXn8aOgfj8J5HwcKZAQoCK/Te3MQ==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age17q5ljstyzkvqtejwfnyf5jvqduars2yauw7vtgu5fcf54tm2jf0sspvt3c
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBzNXJHNlIyVllpMUVNb3Fp
+            WHdkQmIrT21BVU16bTZ4aUpjeFN0WDRyV0ZBClNpa0tIZytia0MzVGtraDhiMW9K
+            Uk9EeGFQaklQb0VGOFNVcmp0dmhyRVUKLS0tIEVaSC9WeVBTSnBMbDRYamZhZDZ1
+            M0RXOXM5OGU1dkRXM2J5c0Y0U0pSVlUKxowkW4modPnZPAfX3lNdsSho8l1Rq+X4
+            Uem0RlltTVYzhhgGo4qDqcl4th0bE0Oxtw4pXOFCxygKlRoFz5xefw==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1x9v4ps90txy9mk4392uya93tyzx40te4dvns4chg5s6q8mfy03ns74jpay
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBPdDRtWWJIcTlldERYYm1M
+            RDgzU24weTFINyt1RGFkUWc3YnZmZkJ3YTNJClBnZ0x6K1lHT1dlazAzRnJhQ0p0
+            Vk0ydHlxMHQyOGtlM1JiWmZKdG45OTAKLS0tIHcrSk9kZEhEVjdzakhNdmRxenk0
+            V012Z05sQTNEeG4wTTc2NE5DTFA4aEEK/Q6j3bl+sJow/UwER5tKmrctIPPzhLZw
+            HMf9Ym9AWaSskakgO5T7J3r3dfzKtzj467vjBORAbwzfYxhFqIZGIQ==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1f4yuh4j3gqafjduusfpxz3na9xtwth9s6gznq043mfex0zglp5jqkkdm64
+    encrypted_regex: secret$
+    lastmodified: "2026-08-09T01:57:29Z"
+    mac: ENC[AES256_GCM,data:fxUCz+79mO3fd4MEaTO3dthK43aAeoNXp8PwsQY0MNret7JdbOwK5o1b/jEeLimQy4ZXA9fe4ufSTsPhgsSr/awqlZyXPl/Ofv08tXXLJzMJq85ezCWaxYBS32xv9G8Lpd6E7VFZuhMeFqRfzGAWNA0bTvTThCz258IoKaOugHc=,iv:yc0e4dp3T7n8f3YbOeccxg+W93YpDrMTMcjdsZ7axbU=,tag:fHrhhMwut3ag12Gb8rDgrQ==,type:str]
+    version: 3.13.3


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* __->__ #1740

Design: Add Synapse staticClient to Dex and synapse OIDC provider
  pointing at Dex issuer; restrict sops encryption to secret keys only.
Related: dex overlays, synapse overlays
Signed-off-by: Shikanime Deva <william.phetsinorath@shikanime.studio>
Change-Id: I4b4c3e6043d7d03d206d84cdaa46a50f6a6a6964