### PR TITLE
Wire Honcho memory provider into Hermes agent

### DIFF
--- a/apps/hermes-agent/components/honcho/patch-sts.yaml
+++ b/apps/hermes-agent/components/honcho/patch-sts.yaml
@@ -9,4 +9,4 @@ spec:
         - name: hermes-agent
           env:
             - name: HONCHO_BASE_URL
-              value: http://hermes-agent.shikanime.svc.cluster.local:8000
+              value: http://honcho.shikanime.svc.cluster.local:8000

--- a/apps/hermes-agent/overlays/nishir-tailnet/kustomization.yaml
+++ b/apps/hermes-agent/overlays/nishir-tailnet/kustomization.yaml
@@ -1,6 +1,8 @@
 resources:
   - ../nishir
   - ingress.yaml
+components:
+  - ../../components/honcho
 namespace: shikanime
 labels:
   - includeTemplates: true

--- a/apps/hermes-agent/overlays/nishir/hermes-agent/config.yaml
+++ b/apps/hermes-agent/overlays/nishir/hermes-agent/config.yaml
@@ -396,7 +396,7 @@ memory:
   memory_char_limit: 2200
   memory_enabled: true
   nudge_interval: 10
-  provider: local
+  provider: honcho
   user_char_limit: 1375
   user_profile_enabled: true
 moa:

--- a/apps/hermes-agent/overlays/nishir/kustomization.yaml
+++ b/apps/hermes-agent/overlays/nishir/kustomization.yaml
@@ -5,6 +5,7 @@ components:
   - ../../components/api
   - ../../components/browser
   - ../../components/dashboard
+  - ../../components/honcho
   - ../../components/webhook
 patches:
   - path: patch-pvc.yaml


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #1741

The components/honcho component existed but was never referenced by any
overlay, and its HONCHO_BASE_URL pointed at hermes-agent instead of the
honcho Service. Activate Honcho as the memory backend:

- Fix HONCHO_BASE_URL to http://honcho.shikanime.svc.cluster.local:8000
- Add components/honcho to nishir and nishir-tailnet overlays
- Set memory.provider: honcho in the nishir gateway config

Design: Honcho is a memory provider plugin; activation requires both the
HONCHO_BASE_URL env var and memory.provider: honcho in config.yaml.
Related: apps/honcho