### PR TITLE
Wire Dex to lldap connector; retire local staticPasswords

### DIFF
--- a/.sops.yaml
+++ b/.sops.yaml
@@ -3,7 +3,7 @@ creation_rules:
       age17q5ljstyzkvqtejwfnyf5jvqduars2yauw7vtgu5fcf54tm2jf0sspvt3c,
       age1x9v4ps90txy9mk4392uya93tyzx40te4dvns4chg5s6q8mfy03ns74jpay,
       age1f4yuh4j3gqafjduusfpxz3na9xtwth9s6gznq043mfex0zglp5jqkkdm64
-    encrypted_regex: secret$
+    encrypted_regex: (secret|bindPW)$
     path_regex: apps/dex/overlays/.*/dex/config\.enc\.yaml
   - age:
       age17q5ljstyzkvqtejwfnyf5jvqduars2yauw7vtgu5fcf54tm2jf0sspvt3c,


### PR DESCRIPTION
## Summary
- Add `apps/lldap` (LLDAP LDAP server) with StatefulSet + PVC, nishir/nishir-tailnet overlays, and gatekeeper mutation excluding the `lldap` workload.
- Point Dex's LDAP connector at `lldap.shikanime.svc.cluster.local:3890` (bindDN admin, bindPW matches lldap admin password); `shikanime.deva` user created in lldap.
- Remove the invalid `oauth2.passwordConnector: local` that was crashing Dex (CrashLoopBackOff) — pure LDAP auth now.

## Verification
- lldap Ready (Restarts 0, PVC persisted at /data).
- Dex Live: Ready, opens LDAP sessions to lldap with no bind errors.
- kustomize build passes for both lldap overlays.

## Note
The live Dex secret was patched to remove `passwordConnector: local`; this PR makes the git source authoritative so Flux reconcile stays consistent.