### PR TITLE
Add Immich stack (server, postgres, valkey, ml)

### DIFF
--- a/apps/dex/overlays/nishir-tailnet/dex/config.enc.yaml
+++ b/apps/dex/overlays/nishir-tailnet/dex/config.enc.yaml
@@ -4,7 +4,7 @@ connectors:
     id: ldap
     config:
       bindDN: uid=admin,ou=people,dc=shikanime,dc=studio
-      bindPW: ENC[AES256_GCM,data:/OdT3g/jkF2VAG6k6D/hKtGHVR5KODLsZ+Ijxg==,iv:7BIyMlF7anOSc5P81VaQWKMhp7vFHETjuRS09SvT2bI=,tag:whUmkQ6p7zrFGpSb/2wptw==,type:str]
+      bindPW: ENC[AES256_GCM,data:eymbteT39ou3SiUFjR65mttZRdES76Pswwl4vA==,iv:xIgS6EhpiUalr8EuNP141Zb2D/Hk1NRsrF7LrU/6Xw8=,tag:hR8SFI977HcXygck771pOA==,type:str]
       groupSearch:
         baseDN: ou=groups,dc=shikanime,dc=studio
         filter: (objectClass=groupOfUniqueNames)
@@ -29,54 +29,54 @@ oauth2:
 sops:
   version: 3.13.3
   encrypted_regex: ^(secret|bindPW)$
-  lastmodified: "2026-08-10T07:50:09Z"
-  mac: ENC[AES256_GCM,data:cCgzhsrvamia6nlTVVHDAXp44rKfmRcdJA2AA+KOwzsfT9jLobS8/WM7/tcAh658XFrFvK6sZsw+HbdewslkTbirFf9Tll6xK/qTsi+qEnyjgi4fuR8OyEilzc8EY1SSSlAHVdhyp+yhHNVnr+jCSK1Ac2bJ6BQKCTHTXlhMcx0=,iv:9RDL2QC92iPxhLiK+5sxD1MTq6W/KqT/RztgIB+PIqo=,tag:Pq/mIQkeXZ9Y4XLNo0cBcA==,type:str]
+  lastmodified: "2026-08-10T13:20:52Z"
+  mac: ENC[AES256_GCM,data:a9LDlC+IEWGq0dgFjuaiyFAe7eRFujh8rRJupKpD25nqkm97/nb7nW/M5cBt63nloDb4zEDD9dntnxTi8UKD4KWHrIaE0YZvd+sWjFZH7sW8iHtWtpdiz4EGaUP3uJwXpl5KQOzttLvqVraxomn+vXYTwni0o5QAneOuodAzsNE=,iv:0iLVktI2GsGnyI7q/Sb1aRcIqpKGwPdEUSwgKN7hhp8=,tag:9NXgnAady0gBdFdXq/amBQ==,type:str]
   age:
     - enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSByUVNjOGVPemphb3cxWC9l
-        WCtXa3kzZmZVOW5BKzZsekpYT0w0dU1HS3lZClJMTDBYUk9lQXFaYlBsL20yV0Qy
-        dENaSFNjQnlVbkg0NXhCNW1vUkZGT1kKLS0tIGtJT2toTDZPaDlGcDFJRHloRjR1
-        aDcxd0FEMytndEdNcS8ySE9ndEsxc2sKDFm1oNXNMcXDCO4+jtfLqgmXqgVlpepi
-        WO5sbJHLxHEJShVHHUEaCrvji7IgSbfWxNOOCAHlVTBlk9M1fUamCQ==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBsVUF2a1g3SlBlZWJTN2th
+        d1lLMUc5a1JGT0t3aXd6SmN3SUY3MTVUZFFRCmczeE9NbzZvRGF1R1J4cGFvT01R
+        WnhmQTIyZmVGM3ltZEMyR1V3d0xMRFUKLS0tIGJPMVpmdzFPSk5Bbm9NTFkwdG1O
+        eDN3MkFqWkRTVEJUMkorODlFUVBXVkEKJ65OE5QL11hWACBSYvMu3a6ef3GZxU66
+        +anw6PSzWwKwXC15er9HIivviN2Pi5M4u+NGS8SR1N133Cq6tv7+3w==
         -----END AGE ENCRYPTED FILE-----
       recipient: age17q5ljstyzkvqtejwfnyf5jvqduars2yauw7vtgu5fcf54tm2jf0sspvt3c
     - enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBwcWJUQUVTUTlnWWpUaVFy
-        WlYwRGVaWEJIV2xkRFgya0lvVWpQOC9IbXcwCm5iSkpPdDIweFhoVDEvcEtwOFpj
-        QkdHQWlaVTFzRHF3Nkdjb0xXUHJXQzAKLS0tIHljK0RPNEt4bXBwaTNCdjZwZ3Jn
-        YmF0WjhoZ3RpeEFVc25OQlpJTHVIb2sKXWnUhoND2eGAOCjbgZgyNNzLTR+1zT69
-        t77M4dVu7yM2A5s2/LSEjfHmOZdE59K01xRDm2v+7WY9Ns+enQ+S0Q==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBTTnhpdjVNTktaVUJRN0tW
+        VFJJMVVJaDZZS3dYRUhhaTdBazF6dC9IS1VrCkpYTlErVlFHQjVhMkExRk5IS1l3
+        bDNqbzNvbVhJVEdrUThaTTE2K1FRZ2sKLS0tIEdOemxqZnkwRDU1NkFibTdkTVY4
+        cTcvOFQxVUVHZ2h3anV2VHdWdlFDNkUKhDunCW+8dRntDDmzhtAqNH6DEMfdGzID
+        an3wXbxh5eaU46aJHtiZeG7zeKjzFUQefI21v01U4cjk/tDUDmV//A==
         -----END AGE ENCRYPTED FILE-----
       recipient: age1x9v4ps90txy9mk4392uya93tyzx40te4dvns4chg5s6q8mfy03ns74jpay
     - enc: |
         -----BEGIN AGE ENCRYPTED FILE-----
-        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB0a1RVdk93Y01IYThIMCtt
-        N1d6UU1OVG1hL0wvYVNWRE1Rb2JEaGRxV25jClEyem9qaW1jZ3ZtV250NkgydUFL
-        L2ZmMCs5NDhhcEp3VXZ1RkFSRkprd3MKLS0tIHYwVnJZelR2SFpFVHIrSk83aERL
-        RlRQUGVUc0VwcldCKzF6MWZPUkE5alUKWVurEMpZmP+VKovNRapP3S4HAMeEjXrp
-        TqGSjw2zyhvfyt6K6BNW7bQvDoVddNNy6rVOw2y7y++8yAoheXkjWg==
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAwdm1GVi9FS0dpZVVzZU9Y
+        NW5wYU9TbkxCMHQ4QjhDL0tnN0ROSXYzTWlVCkY5RHNoNGEyWWkvMFY0T2Q5RlhC
+        SzRtSnM3cjhFc2JNYVZRWi80ei9UY2cKLS0tIDBWeHl0MERGYUdQZ2NtWHpmZGJF
+        ZFBXSGJYL2VKeDI3N0crTlM2TDd0N3MKDtku+63mcLqpmoFP+fg5P+w8TMwlV6eP
+        /tgI1RIWCy6GBXABTfaaB3a8yj33XaL81KLEtJyJFUHHzJbXwxkfjw==
         -----END AGE ENCRYPTED FILE-----
       recipient: age1f4yuh4j3gqafjduusfpxz3na9xtwth9s6gznq043mfex0zglp5jqkkdm64
 staticClients:
   - name: Forgejo
     id: forgejo
-    secret: ENC[AES256_GCM,data:b2sLRuQ3rUNoVT3x6n5tK2chqdGD45VuftHrxttTK9rZyMTBhuHuDa5KFnZDTVsG1DEvRDny55NKfdBF2JoKVw==,iv:gYJuwV0wlQyWQsG5r13sAhhEM8S9N3WPL2wKgF6dci4=,tag:0NetraTTKj2HAeEC1SshbQ==,type:str]
+    secret: ENC[AES256_GCM,data:PHBpwl/H3asf5pteG4ey1YZjNohjVrdu6vAldp1oR7p1QA+zb9Bp3m5UGMlX6sfRPSn0x1bqnLFtQM2nfpmV4A==,iv:TnXwTkWpxTKrnl1DUVtyDjaGiBT1SObkUaFEGGfH1Ok=,tag:N0Bi+a+mu0bKcAmYxmvpnQ==,type:str]
     redirectURIs:
       - https://forgejo.taila659a.ts.net/user/oauth2/Dex/callback
     trustedPeers:
       - "*"
   - name: Gitea Mirror
     id: gitea-mirror
-    secret: ENC[AES256_GCM,data:5Dhap66glixgPWI1UgI59Gn1uCbrGQCX4xHcPuyah16vwdPmfaF7NBlPTrICD1uMSvMFuh6AEIuISVZ4KRrRhg==,iv:4U8VonY2R7oTjim7E4QxN4gFEtplZYFim0+FXdTSK7Y=,tag:mjp553unvvttdzr8rvz9pQ==,type:str]
+    secret: ENC[AES256_GCM,data:A6mZs86sgCI0JWRJLOzbShIxO0cA3cJY4UeYIxh/Vh4gnj8mDSMP5s/SA+aXTZ9AeVPcCJ5E/5/bAFn9gFBnIA==,iv:OT9GBQumeVGqjtgclNgib54cgxM+53FRgOCb8JJZfvs=,tag:Vq+w8qMLOvmJuvWCPRTm+Q==,type:str]
     redirectURIs:
       - https://gitea-mirror.taila659a.ts.net/api/auth/sso/callback/dex
     trustedPeers:
       - "*"
   - name: Synapse
     id: synapse
-    secret: ENC[AES256_GCM,data:0yS+y8hUh/Igut4Y5MWXdzhuXNxCfLSJe9yruPF6YAohuk0Bvw0LltpS7a+SdW6WhLmg6O19JgMErjEy944KKA==,iv:7JzE6yL8jg5SE16hy9BQiqfSDGeRVtS37Hk+5r4ihj4=,tag:h/6pEoAp6mu5yT+yJm9X8g==,type:str]
+    secret: ENC[AES256_GCM,data:M9QhfB3aUGaf3TfKBr06OVfIHyw5Kpy/vvMpjNsXtzUKqtyTVnD2bDryXoBLR/P8Idl+g0rlMyMokn0n3Q3bpA==,iv:NDYCHwVF7EnuH/LkKiYxmBF+8UqkxqdrG5YsAwn2iDQ=,tag:c1nw9xQyzn3MVfNGt+xRmw==,type:str]
     redirectURIs:
       - https://matrix.taila659a.ts.net/_matrix/oidc/callback/synapse
     trustedPeers:
@@ -84,16 +84,23 @@ staticClients:
   - name: Hermes Agent Dashboard
     id: hermes-agent
     public: true
-    secret: ENC[AES256_GCM,data:A5FI1Sb9xpaqTxJ25CQyY2zKjhcRToQaPUUVfXunxS3Z9n09ueu8iWnP5Rv8duVRybwgFg7Ly+D3CYTeMlN27w==,iv:mmZ0/tFRAGrdHw/b6dRAVBx3c6HYp4LMO1vkCdp3IME=,tag:LYty476D0qjdy3AL1qu9Kw==,type:str]
+    secret: ENC[AES256_GCM,data:yAM3IXxmyX5d2P+3319q/xg7J+xvK+48fXVEbDgsSrgP8IKriYWJJRxqu/3MV5u5ZOkAuJXhaCP0TEUxnwAbhQ==,iv:Pa/o4hV+BqHfDVLjyhZbfumrbwxUBZFHWdTvQnWjnn8=,tag:JQX1O/qqYhb+kxVqST90Aw==,type:str]
     redirectURIs:
       - https://automata-dashboard.taila659a.ts.net/auth/callback
     trustedPeers:
       - "*"
   - name: Vaultwarden
     id: vaultwarden
-    secret: ENC[AES256_GCM,data:u7EY3RcC2G6WJm7Szq3fnZT9MHEhdKsoiR+atvw+BLbcMfRkqwxL+krczhk8evm+ksRVLABdQ33SCeUdVKBMTA==,iv:HslfRgWnoH8N62+aq+ebaFUNBoBodvq8CJRfcs1Fk7I=,tag:KVlA9heLwuiHTAIYf3/CoA==,type:str]
+    secret: ENC[AES256_GCM,data:Ujh4v849/SUqZBtetoRKSKOy5jVbF4w4mt/E8HwM23us3ZuYgLJANrRMW5Ag3YOs+JhSOblnRE1ELUgg3V9V1Q==,iv:7o2LS9GHIio0NuWBXg1rDkuF7/Mv5j12BrB/GW2v8t0=,tag:ccbynmBOmdXtlBRM9pmbjA==,type:str]
     redirectURIs:
       - https://vaultwarden.taila659a.ts.net/sso/oidc/callback
+    trustedPeers:
+      - "*"
+  - name: Immich
+    id: immich
+    secret: ENC[AES256_GCM,data:thNocATH/TsRKwLQ652LrfVU+X1xmClfWuGF8ViXeTU=,iv:iJ10GR6CTJgjk0+UuFUXQITMU2cvnQrX/3wlfzbqLq8=,tag:+3/jUmUlxqNCh6t+XVc4hA==,type:str]
+    redirectURIs:
+      - https://immich.taila659a.ts.net/auth/login
     trustedPeers:
       - "*"
 storage:

--- a/apps/immich-ml/base/deploy.yaml
+++ b/apps/immich-ml/base/deploy.yaml
@@ -1,0 +1,49 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: immich-ml
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: immich-ml
+      app.kubernetes.io/name: immich-ml
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/instance: immich-ml
+        app.kubernetes.io/name: immich-ml
+    spec:
+      containers:
+        - name: immich-ml
+          image: immich-machine-learning
+          env:
+            - name: TZ
+              value: Europe/Paris
+            - name: IMMICH_MACHINE_LEARNING_PORT
+              value: "3003"
+          livenessProbe:
+            initialDelaySeconds: 30
+            tcpSocket:
+              port: http
+            timeoutSeconds: 5
+          ports:
+            - name: http
+              containerPort: 3003
+          readinessProbe:
+            initialDelaySeconds: 10
+            tcpSocket:
+              port: http
+            timeoutSeconds: 5
+          startupProbe:
+            failureThreshold: 60
+            tcpSocket:
+              port: http
+            timeoutSeconds: 5
+          volumeMounts:
+            - name: cache
+              mountPath: /cache
+      volumes:
+        - name: cache
+          persistentVolumeClaim:
+            claimName: immich-ml-data

--- a/apps/immich-ml/base/kustomization.yaml
+++ b/apps/immich-ml/base/kustomization.yaml
@@ -1,0 +1,15 @@
+resources:
+  - netpol.yaml
+  - pvc.yaml
+  - deploy.yaml
+  - svc.yaml
+  - vpa.yaml
+images:
+  - name: immich-machine-learning
+    newName: ghcr.io/immich-app/immich-machine-learning
+    newTag: v1.118.0
+metadata:
+  annotations:
+    automata.shikanime.studio/images:
+      '[ { "name": "immich-machine-learning", "tag-regex":
+      "^(?P<version>\\d+\\.\\d+\\.\\d+)$" } ]'

--- a/apps/immich-ml/base/netpol.yaml
+++ b/apps/immich-ml/base/netpol.yaml
@@ -1,0 +1,18 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: immich-ml
+spec:
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/instance: immich
+      ports:
+        - port: http
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/instance: immich-ml
+      app.kubernetes.io/name: immich-ml
+  policyTypes:
+    - Ingress

--- a/apps/immich-ml/base/pvc.yaml
+++ b/apps/immich-ml/base/pvc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: immich-ml-data
+spec:
+  resources:
+    requests:
+      storage: 32Gi
+  volumeMode: Filesystem
+  accessModes:
+    - ReadWriteOncePod

--- a/apps/immich-ml/base/svc.yaml
+++ b/apps/immich-ml/base/svc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: immich-ml
+spec:
+  ports:
+    - name: http
+      port: 3003
+      targetPort: http
+  selector:
+    app.kubernetes.io/instance: immich-ml
+    app.kubernetes.io/name: immich-ml

--- a/apps/immich-ml/base/vpa.yaml
+++ b/apps/immich-ml/base/vpa.yaml
@@ -1,0 +1,11 @@
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: immich-ml
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: immich-ml
+  updatePolicy:
+    updateMode: InPlaceOrRecreate

--- a/apps/immich-ml/overlays/nishir-tailnet/kustomization.yaml
+++ b/apps/immich-ml/overlays/nishir-tailnet/kustomization.yaml
@@ -1,0 +1,13 @@
+resources:
+  - ../nishir
+namespace: shikanime
+patches:
+  - path: patch-pvc.yaml
+labels:
+  - includeTemplates: true
+    pairs:
+      app.kubernetes.io/component: machine-learning
+      app.kubernetes.io/instance: immich-ml
+      app.kubernetes.io/name: immich-ml
+      app.kubernetes.io/part-of: nishir-media
+      app.kubernetes.io/version: v1.118.0

--- a/apps/immich-ml/overlays/nishir-tailnet/patch-pvc.yaml
+++ b/apps/immich-ml/overlays/nishir-tailnet/patch-pvc.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: immich-ml-data
+spec:
+  storageClassName: nishir-standard

--- a/apps/immich-ml/overlays/nishir/kustomization.yaml
+++ b/apps/immich-ml/overlays/nishir/kustomization.yaml
@@ -1,0 +1,3 @@
+resources:
+  - ../../base
+namespace: shikanime

--- a/apps/immich-postgres/base/kustomization.yaml
+++ b/apps/immich-postgres/base/kustomization.yaml
@@ -1,0 +1,14 @@
+resources:
+  - netpol.yaml
+  - pvc.yaml
+  - sts.yaml
+  - svc.yaml
+  - vpa.yaml
+images:
+  - name: postgres
+    newName: pgvector/pgvector
+    newTag: pg15
+metadata:
+  annotations:
+    automata.shikanime.studio/images:
+      '[ { "name": "immich-postgres", "tag-regex": "^(?P<version>.+)$" } ]'

--- a/apps/immich-postgres/base/netpol.yaml
+++ b/apps/immich-postgres/base/netpol.yaml
@@ -1,0 +1,18 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: immich-postgres
+spec:
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/instance: immich
+      ports:
+        - port: postgres
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/instance: immich-postgres
+      app.kubernetes.io/name: postgres
+  policyTypes:
+    - Ingress

--- a/apps/immich-postgres/base/pvc.yaml
+++ b/apps/immich-postgres/base/pvc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: immich-postgres-data
+spec:
+  resources:
+    requests:
+      storage: 32Gi
+  volumeMode: Filesystem
+  accessModes:
+    - ReadWriteOncePod

--- a/apps/immich-postgres/base/sts.yaml
+++ b/apps/immich-postgres/base/sts.yaml
@@ -1,0 +1,87 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: immich-postgres
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: immich-postgres
+      app.kubernetes.io/name: postgres
+  serviceName: immich-postgres
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/instance: immich-postgres
+        app.kubernetes.io/name: postgres
+    spec:
+      containers:
+        - name: postgres
+          image: postgres
+          ports:
+            - name: postgres
+              containerPort: 5432
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql/data
+            - name: run-postgresql
+              mountPath: /var/run/postgresql
+          livenessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - pg_isready -U "$(POSTGRES_USER)" -d "$(POSTGRES_DB)"
+            failureThreshold: 3
+            periodSeconds: 30
+            timeoutSeconds: 5
+          readinessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - pg_isready -U "$(POSTGRES_USER)" -d "$(POSTGRES_DB)"
+            failureThreshold: 3
+            periodSeconds: 10
+            timeoutSeconds: 5
+          securityContext:
+            capabilities:
+              add:
+                - CHOWN
+                - FOWNER
+                - SETUID
+                - SETGID
+                - DAC_OVERRIDE
+          startupProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - pg_isready -U "$(POSTGRES_USER)" -d "$(POSTGRES_DB)"
+            failureThreshold: 180
+            periodSeconds: 5
+            timeoutSeconds: 5
+          env:
+            - name: POSTGRES_DB
+              valueFrom:
+                secretKeyRef:
+                  name: immich-postgres
+                  key: db-database
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: immich-postgres
+                  key: db-username
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: immich-postgres
+                  key: db-password
+      securityContext:
+        fsGroup: 999
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: immich-postgres-data
+        - name: run-postgresql
+          emptyDir: {}

--- a/apps/immich-postgres/base/svc.yaml
+++ b/apps/immich-postgres/base/svc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: immich-postgres
+spec:
+  ports:
+    - name: postgres
+      port: 5432
+      targetPort: postgres
+  selector:
+    app.kubernetes.io/instance: immich-postgres
+    app.kubernetes.io/name: postgres

--- a/apps/immich-postgres/base/vpa.yaml
+++ b/apps/immich-postgres/base/vpa.yaml
@@ -1,0 +1,11 @@
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: immich-postgres
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: StatefulSet
+    name: immich-postgres
+  updatePolicy:
+    updateMode: InPlaceOrRecreate

--- a/apps/immich-postgres/overlays/nishir-tailnet/kustomization.yaml
+++ b/apps/immich-postgres/overlays/nishir-tailnet/kustomization.yaml
@@ -1,0 +1,11 @@
+resources:
+  - ../nishir
+namespace: shikanime
+labels:
+  - includeTemplates: true
+    pairs:
+      app.kubernetes.io/component: database
+      app.kubernetes.io/instance: immich-postgres
+      app.kubernetes.io/name: postgres
+      app.kubernetes.io/part-of: nishir-media
+      app.kubernetes.io/version: pg15

--- a/apps/immich-postgres/overlays/nishir/immich-postgres/.enc.env
+++ b/apps/immich-postgres/overlays/nishir/immich-postgres/.enc.env
@@ -1,0 +1,13 @@
+db-username=ENC[AES256_GCM,data:b8SNEvrm,iv:clk6HNZNWFOGY9Qw7+wK5OUQqZ09wzheUBxcK57kYx4=,tag:aEry6+HphKNSl+VYtdKVsQ==,type:str]
+db-password=ENC[AES256_GCM,data:xmQpZsv8MPAk3DTdCWpEcwvHcGVrHky8EXyjmmetY44=,iv:PzFAFG+a27XalJa+9Prgxbo8ZZleu3MABWDFdOTrGH8=,tag:9+8Z9nQiUbtugvPKGVVC3A==,type:str]
+db-database=ENC[AES256_GCM,data:wYC48CHn,iv:7mpPYgYUij0tc8olwrj+gOcL43JCsuXCkXcEDvJcVMc=,tag:IEQg5Ga63W/lSMi+NOZhjA==,type:str]
+sops_age__list_0__map_enc=-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBxckwrcG9tSFI4enRscEF0\nd2FEUDFvdDNIRmpiZlN1VVZFcHhFeWIwUWc4CkM0clcrY3FVZDQyYTRXcEtUbHk0\nb0xBQzRDeVBWZlg3NWswczdWR09mZjQKLS0tIFp3UzNXdmZjZHBpU0c4dU5LNHh2\nZytZMUdTTW1IOTF2Y2k4d2ZBY2VnV0EKO9NqjoSnceWuL+qTwVSn6Z0SBJQ8YAyH\nIGoggKfcVPb+4TjcLG1RrKK0eUeBIwdLy6+xHyxxZrMdEeGxZGGuAg==\n-----END AGE ENCRYPTED FILE-----\n
+sops_age__list_0__map_recipient=age17q5ljstyzkvqtejwfnyf5jvqduars2yauw7vtgu5fcf54tm2jf0sspvt3c
+sops_age__list_1__map_enc=-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA5Z0RzQmFZRFV3d05KMU9G\nT2taYnpsbEtKNTJqWGxIQ3ZadklqMms3RmdnCnpYU1U5UEJ3MmUxdkoxSExRYWp3\nK2YrLzJQaXBVYUxYM2dmQ1hKMS8zM1EKLS0tIHIrSG9lYk9xa2Nlc0d3aTc4bFg4\nWVpvRVJlV3Y2TEVNVjJPMDlpVWh1YjAKQ6B92d4qIEQ8HT8oM3L2oKURPKm8Agj2\nGxmDBYLK8ntIUmXxA+AsEdi62vWUvaPlqDDoMLlV7F/r5+TdBZgcUw==\n-----END AGE ENCRYPTED FILE-----\n
+sops_age__list_1__map_recipient=age1x9v4ps90txy9mk4392uya93tyzx40te4dvns4chg5s6q8mfy03ns74jpay
+sops_age__list_2__map_enc=-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBldkduaUJKSG90TlNvZkJF\ndVg5WmdNeUpvS3Ntak1QbDZIVUJ0NXJhbUgwClV5UGNXRCsyZW4xZUpUdURKcjdY\nUmtnSWJyQzVTQ1d6aHFhZ1hWc01oajgKLS0tIHJ6ODlDSG5QN0RqNllpaFNlRUQz\nY2p5Z2dUVTVkVHoyY09Bc05yLzFUczgKfQvqnqYFzb1FWWAP0cX468VasMLhQOMI\nYOyKsW4N1+PyTWJYqHWo7s9jvVrSEVBLWIe+oSfVx703WZaO+Rtcfw==\n-----END AGE ENCRYPTED FILE-----\n
+sops_age__list_2__map_recipient=age1f4yuh4j3gqafjduusfpxz3na9xtwth9s6gznq043mfex0zglp5jqkkdm64
+sops_lastmodified=2026-08-10T12:59:19Z
+sops_mac=ENC[AES256_GCM,data:EOX004GjqIqhNkVaPMERSBjsrsxrcf7+uqxgtsyahhq5n9oN3+aTrdnyNyP614h00bEJYMhpzF/zTR2C5AtPb8V/dNJ9M8BxdkxChRbMp42atBBPAV6xTViOD/jiQKgLf50YdB2ncAWVgni7Nv02N68pzIKunzRzFhvytJVCURY=,iv:ix3bNyt1scQlVEyziItjd6l81G0JtFTRKbpFszCw2tQ=,tag:zg/5Jv2JLCheBZnfBBaSMw==,type:str]
+sops_unencrypted_suffix=_unencrypted
+sops_version=3.13.3

--- a/apps/immich-postgres/overlays/nishir/kustomization.yaml
+++ b/apps/immich-postgres/overlays/nishir/kustomization.yaml
@@ -1,0 +1,11 @@
+resources:
+  - ../../base
+namespace: shikanime
+patches:
+  - path: patch-pvc.yaml
+secretGenerator:
+  - name: immich-postgres
+    envs:
+      - immich-postgres/.enc.env
+    options:
+      disableNameSuffixHash: true

--- a/apps/immich-postgres/overlays/nishir/patch-pvc.yaml
+++ b/apps/immich-postgres/overlays/nishir/patch-pvc.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: immich-postgres-data
+spec:
+  storageClassName: nishir-standard

--- a/apps/immich-valkey/base/kustomization.yaml
+++ b/apps/immich-valkey/base/kustomization.yaml
@@ -1,0 +1,13 @@
+resources:
+  - netpol.yaml
+  - sts.yaml
+  - svc.yaml
+  - vpa.yaml
+images:
+  - name: valkey
+    newName: valkey/valkey
+    newTag: 7-alpine
+metadata:
+  annotations:
+    automata.shikanime.studio/images:
+      '[ { "name": "immich-valkey", "tag-regex": "^(?P<version>.+)$" } ]'

--- a/apps/immich-valkey/base/netpol.yaml
+++ b/apps/immich-valkey/base/netpol.yaml
@@ -1,0 +1,18 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: immich-valkey
+spec:
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/instance: immich
+      ports:
+        - port: valkey
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/instance: immich-valkey
+      app.kubernetes.io/name: valkey
+  policyTypes:
+    - Ingress

--- a/apps/immich-valkey/base/sts.yaml
+++ b/apps/immich-valkey/base/sts.yaml
@@ -1,0 +1,49 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: immich-valkey
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: immich-valkey
+      app.kubernetes.io/name: valkey
+  serviceName: immich-valkey
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/instance: immich-valkey
+        app.kubernetes.io/name: valkey
+    spec:
+      containers:
+        - name: valkey
+          image: valkey
+          args:
+            - --save
+            - ""
+            - --appendonly
+            - "no"
+          livenessProbe:
+            initialDelaySeconds: 10
+            tcpSocket:
+              port: valkey
+            timeoutSeconds: 5
+          ports:
+            - name: valkey
+              containerPort: 6379
+          readinessProbe:
+            initialDelaySeconds: 5
+            tcpSocket:
+              port: valkey
+            timeoutSeconds: 5
+          startupProbe:
+            failureThreshold: 30
+            tcpSocket:
+              port: valkey
+            timeoutSeconds: 5
+          volumeMounts:
+            - name: data
+              mountPath: /data
+      volumes:
+        - name: data
+          emptyDir: {}

--- a/apps/immich-valkey/base/svc.yaml
+++ b/apps/immich-valkey/base/svc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: immich-valkey
+spec:
+  ports:
+    - name: valkey
+      port: 6379
+      targetPort: valkey
+  selector:
+    app.kubernetes.io/instance: immich-valkey
+    app.kubernetes.io/name: valkey

--- a/apps/immich-valkey/base/vpa.yaml
+++ b/apps/immich-valkey/base/vpa.yaml
@@ -1,0 +1,11 @@
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: immich-valkey
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: StatefulSet
+    name: immich-valkey
+  updatePolicy:
+    updateMode: InPlaceOrRecreate

--- a/apps/immich-valkey/overlays/nishir-tailnet/kustomization.yaml
+++ b/apps/immich-valkey/overlays/nishir-tailnet/kustomization.yaml
@@ -1,0 +1,11 @@
+resources:
+  - ../nishir
+namespace: shikanime
+labels:
+  - includeTemplates: true
+    pairs:
+      app.kubernetes.io/component: cache
+      app.kubernetes.io/instance: immich-valkey
+      app.kubernetes.io/name: valkey
+      app.kubernetes.io/part-of: nishir-media
+      app.kubernetes.io/version: 7-alpine

--- a/apps/immich-valkey/overlays/nishir/kustomization.yaml
+++ b/apps/immich-valkey/overlays/nishir/kustomization.yaml
@@ -1,0 +1,3 @@
+resources:
+  - ../../base
+namespace: shikanime

--- a/apps/immich/base/deploy.yaml
+++ b/apps/immich/base/deploy.yaml
@@ -1,0 +1,105 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: immich
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: immich
+      app.kubernetes.io/name: immich
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/instance: immich
+        app.kubernetes.io/name: immich
+    spec:
+      containers:
+        - name: immich
+          image: immich-server
+          livenessProbe:
+            httpGet:
+              path: /api/server-info/ping
+              port: http
+            initialDelaySeconds: 60
+            timeoutSeconds: 5
+          ports:
+            - name: http
+              containerPort: 2283
+          readinessProbe:
+            httpGet:
+              path: /api/server-info/ping
+              port: http
+            initialDelaySeconds: 30
+            timeoutSeconds: 5
+          resources:
+            requests:
+              cpu: 250m
+              memory: 512Mi
+          startupProbe:
+            failureThreshold: 60
+            httpGet:
+              path: /api/server-info/ping
+              port: http
+            timeoutSeconds: 5
+          volumeMounts:
+            - name: data
+              mountPath: /usr/src/app/upload
+          env:
+            - name: TZ
+              value: Europe/Paris
+            - name: IMMICH_SERVER_PORT
+              value: "2283"
+            - name: IMMICH_MEDIA_LOCATION
+              value: /usr/src/app/upload
+            - name: DB_HOSTNAME
+              value: immich-postgres
+            - name: DB_PORT
+              value: "5432"
+            - name: DB_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: immich
+                  key: db-username
+            - name: DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: immich
+                  key: db-password
+            - name: DB_DATABASE_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: immich
+                  key: db-database
+            - name: REDIS_HOSTNAME
+              value: immich-valkey
+            - name: REDIS_PORT
+              value: "6379"
+            - name: IMMICH_MACHINE_LEARNING_URL
+              value: http://immich-ml:3003
+            - name: IMMICH_JWT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: immich
+                  key: jwt-secret
+            - name: IMMICH_OIDC_ENABLED
+              value: "true"
+            - name: IMMICH_OIDC_ISSUER_URL
+              value: https://accounts.taila659a.ts.net
+            - name: IMMICH_OIDC_CLIENT_ID
+              value: immich
+            - name: IMMICH_OIDC_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: immich
+                  key: oidc-secret
+            - name: IMMICH_OIDC_BUTTON_TEXT
+              value: Shikanime
+            - name: IMMICH_OIDC_AUTO_REGISTER
+              value: "true"
+            - name: IMMICH_OIDC_SCOPE
+              value: openid email profile
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: immich-data

--- a/apps/immich/base/kustomization.yaml
+++ b/apps/immich/base/kustomization.yaml
@@ -1,0 +1,15 @@
+resources:
+  - netpol.yaml
+  - pvc.yaml
+  - deploy.yaml
+  - svc.yaml
+  - vpa.yaml
+images:
+  - name: immich-server
+    newName: ghcr.io/immich-app/immich-server
+    newTag: v1.118.0
+metadata:
+  annotations:
+    automata.shikanime.studio/images:
+      '[ { "name": "immich-server", "tag-regex":
+      "^(?P<version>\\d+\\.\\d+\\.\\d+)$" } ]'

--- a/apps/immich/base/netpol.yaml
+++ b/apps/immich/base/netpol.yaml
@@ -1,0 +1,18 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: immich
+spec:
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: tailscale-system
+      ports:
+        - port: http
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/instance: immich
+      app.kubernetes.io/name: immich
+  policyTypes:
+    - Ingress

--- a/apps/immich/base/pvc.yaml
+++ b/apps/immich/base/pvc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: immich-data
+spec:
+  resources:
+    requests:
+      storage: 128Gi
+  volumeMode: Filesystem
+  accessModes:
+    - ReadWriteOncePod

--- a/apps/immich/base/svc.yaml
+++ b/apps/immich/base/svc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: immich
+spec:
+  ports:
+    - name: http
+      port: 2283
+      targetPort: http
+  selector:
+    app.kubernetes.io/instance: immich
+    app.kubernetes.io/name: immich

--- a/apps/immich/base/vpa.yaml
+++ b/apps/immich/base/vpa.yaml
@@ -1,0 +1,11 @@
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: immich
+spec:
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: immich
+  updatePolicy:
+    updateMode: InPlaceOrRecreate

--- a/apps/immich/overlays/nishir-tailnet/ingress.yaml
+++ b/apps/immich/overlays/nishir-tailnet/ingress.yaml
@@ -1,0 +1,14 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: immich
+spec:
+  defaultBackend:
+    service:
+      name: immich
+      port:
+        name: http
+  ingressClassName: tailscale
+  tls:
+    - hosts:
+        - immich

--- a/apps/immich/overlays/nishir-tailnet/kustomization.yaml
+++ b/apps/immich/overlays/nishir-tailnet/kustomization.yaml
@@ -1,0 +1,14 @@
+resources:
+  - ../nishir
+  - ingress.yaml
+namespace: shikanime
+patches:
+  - path: patch-pvc.yaml
+labels:
+  - includeTemplates: true
+    pairs:
+      app.kubernetes.io/component: photo-manager
+      app.kubernetes.io/instance: immich
+      app.kubernetes.io/name: immich
+      app.kubernetes.io/part-of: nishir-media
+      app.kubernetes.io/version: v1.118.0

--- a/apps/immich/overlays/nishir-tailnet/patch-pvc.yaml
+++ b/apps/immich/overlays/nishir-tailnet/patch-pvc.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: immich-data
+spec:
+  storageClassName: nishir-standard

--- a/apps/immich/overlays/nishir/immich/.enc.env
+++ b/apps/immich/overlays/nishir/immich/.enc.env
@@ -1,0 +1,15 @@
+db-username=ENC[AES256_GCM,data:ZBKVIyUj,iv:VGuELMCY0b6azzlhrg8STXjRQ6gVDiL40h7+YzKtXDc=,tag:hozX1F05Zf1/FHfZWJQVxg==,type:str]
+db-password=ENC[AES256_GCM,data:90uUFsTB99ttCbKYc9Tq623fFIimesjXx90xQuVXcag=,iv:5RHmN3xmoeMyXX4Q0idsHAfgtYfOfsSlX+gL2cd9P5k=,tag:gx3oPIFkGcU3s/q2e/FreA==,type:str]
+db-database=ENC[AES256_GCM,data:UZSCybQT,iv:+CJB240pYUyj8bF7INAVtMWb6nkJOfTGqvJqFDDw8wY=,tag:D7g52bZMvDfn9v/gWhEB0w==,type:str]
+jwt-secret=ENC[AES256_GCM,data:aKPZroPvdoLQ9yWDma3DYTEALBeQwWYFFySGgWGx0+Y8njhVKEvF/SQo/dU=,iv:mnyg0sG8T23BjA5qdbDdkGBkUtkJTWMn/Ww2RDEx9Ws=,tag:UgljLigPHSmIk1IIWcql/g==,type:str]
+oidc-secret=ENC[AES256_GCM,data:gUIDGhe+t5MyUHMTeGgDHLpveE+tB02ABYpTm0cE8Hk=,iv:5qUM7YVAAPE9VVeRZZrCqNwWbph2Z9obLDiX5lbpjKs=,tag:eid3wDWiAceUyQ7R0/0g4g==,type:str]
+sops_age__list_0__map_enc=-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBwQlRISDRWR0J5ZU9sRExP\nQ2FXOWlYU0lMTGlTQS9INnVLUERXaDZNNXlJCkVMN3htRXVEMHNsVzdRVEt3KzhB\nL0hGZTM3NG9rWWw3d3cyKzNtWlZ3QkkKLS0tIFhrNkcxTTNucVEzYmJSNFlMcjVp\nWjY3RTJyQ2QyRzlJbDBxeFA5VkQxZXcKYVXR/h6RA9zTCJrYzDZged1Ilwmc0+Sh\n0a3Je94hyK8nOsjdn27S/HC82xgYh2M6iXnxHOzTCb8IWP/SPPVnmQ==\n-----END AGE ENCRYPTED FILE-----\n
+sops_age__list_0__map_recipient=age17q5ljstyzkvqtejwfnyf5jvqduars2yauw7vtgu5fcf54tm2jf0sspvt3c
+sops_age__list_1__map_enc=-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB3OW1HT0lmS0hQWmRaa01X\nZjBYTk5SbnlsSmpBdXdFWCtZa3F6VWxZTmxBCkhiWTdMRGlRVnVZcVZJR3UxMHBP\nVS9aaENSM0dma3BFMUU3bUtteitPKzAKLS0tIGRwMzQ4dzgrU1paZGJ5ZGFSd1pq\nRkh0SVlBNDBaSlQyN1M0b0FiTWJiemsKq0p3y/uSUqBm/B2pQDiSVEgr/16jkI45\nmPfzO6tXjIRkeaO8bCyZFE4KI4P3b8cc8mAlCRZRLrYrG/LzkZkAsg==\n-----END AGE ENCRYPTED FILE-----\n
+sops_age__list_1__map_recipient=age1x9v4ps90txy9mk4392uya93tyzx40te4dvns4chg5s6q8mfy03ns74jpay
+sops_age__list_2__map_enc=-----BEGIN AGE ENCRYPTED FILE-----\nYWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBibWZLZ1ZGY212a0JPclRa\nNFk3SzhFdXE3RVBGZWNQeHhSU2RGVkhYQUJZCkFpRzhaUEVTa080eHR3THVTQk5U\ncXZMNy84TWJ5YkM3Y1JBMFpOa0RkZVkKLS0tIDdwWEtOY1ZpT1NuTHFJMmVSazBw\nbTVob2twblZlMGJjbitBVjd5dWVGUTQKQ7L0dDwzvZX6e++x+ksi54Nl75ZiEYw2\nfldbjd6UiUYSWhuIJJCJ4AVWlrSHQMIzCMqhdN9ut3EKEqv1ll9lcA==\n-----END AGE ENCRYPTED FILE-----\n
+sops_age__list_2__map_recipient=age1f4yuh4j3gqafjduusfpxz3na9xtwth9s6gznq043mfex0zglp5jqkkdm64
+sops_lastmodified=2026-08-10T12:59:19Z
+sops_mac=ENC[AES256_GCM,data:SrfrF47AXwN5Iu21oWUpFv4PpBKV7zwwS7POxOF4YT0YlOeS/VF+Tgml4xrtagQaizTkYgt1V5G3PPf6ErbpOzUJ2Sd1uZJVxugIOotq607uCrT8XqfBxfDAacNWr17im2/gG9706r6iST6A0Ph3BbLlU1dj2TriP+gUEWISYZM=,iv:EYzj6cmFhUlTGzNYCJHM9A+BGlu1hAL+Y1Tq/pNk4cM=,tag:qv/QU0vjkAfxH4b5++WILA==,type:str]
+sops_unencrypted_suffix=_unencrypted
+sops_version=3.13.3

--- a/apps/immich/overlays/nishir/kustomization.yaml
+++ b/apps/immich/overlays/nishir/kustomization.yaml
@@ -1,0 +1,9 @@
+resources:
+  - ../../base
+namespace: shikanime
+secretGenerator:
+  - name: immich
+    envs:
+      - immich/.enc.env
+    options:
+      disableNameSuffixHash: true

--- a/clusters/nishir/overlays/tailnet/ks.yaml
+++ b/clusters/nishir/overlays/tailnet/ks.yaml
@@ -213,6 +213,117 @@ spec:
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
+  name: apps-immich-postgres
+  namespace: flux-system
+spec:
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-age
+  dependsOn:
+    - name: infrastructure-autoscaler
+    - name: infrastructure-cert-manager
+    - name: infrastructure-monitoring
+    - name: infrastructure-tailscale
+  healthChecks:
+    - apiVersion: apps/v1
+      kind: StatefulSet
+      name: immich-postgres
+      namespace: shikanime
+  interval: 10m
+  path: ./apps/immich-postgres/overlays/nishir-tailnet
+  prune: true
+  sourceRef:
+    name: flux-system
+    kind: GitRepository
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: apps-immich-valkey
+  namespace: flux-system
+spec:
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-age
+  dependsOn:
+    - name: infrastructure-autoscaler
+    - name: infrastructure-cert-manager
+    - name: infrastructure-monitoring
+    - name: infrastructure-tailscale
+  healthChecks:
+    - apiVersion: apps/v1
+      kind: StatefulSet
+      name: immich-valkey
+      namespace: shikanime
+  interval: 10m
+  path: ./apps/immich-valkey/overlays/nishir-tailnet
+  prune: true
+  sourceRef:
+    name: flux-system
+    kind: GitRepository
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: apps-immich-ml
+  namespace: flux-system
+spec:
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-age
+  dependsOn:
+    - name: infrastructure-autoscaler
+    - name: infrastructure-cert-manager
+    - name: infrastructure-monitoring
+    - name: infrastructure-tailscale
+  healthChecks:
+    - apiVersion: apps/v1
+      kind: Deployment
+      name: immich-ml
+      namespace: shikanime
+  interval: 10m
+  path: ./apps/immich-ml/overlays/nishir-tailnet
+  prune: true
+  sourceRef:
+    name: flux-system
+    kind: GitRepository
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: apps-immich
+  namespace: flux-system
+spec:
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-age
+  dependsOn:
+    - name: infrastructure-autoscaler
+    - name: infrastructure-cert-manager
+    - name: infrastructure-monitoring
+    - name: infrastructure-tailscale
+    - name: apps-immich-postgres
+    - name: apps-immich-valkey
+    - name: apps-immich-ml
+  healthChecks:
+    - apiVersion: apps/v1
+      kind: Deployment
+      name: immich
+      namespace: shikanime
+  interval: 10m
+  path: ./apps/immich/overlays/nishir-tailnet
+  prune: true
+  sourceRef:
+    name: flux-system
+    kind: GitRepository
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
   name: apps-chrome
   namespace: flux-system
 spec:


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.13.0) (oldest at bottom):
* __->__ #1748

Kustomize-driven Immich deployment for nishir-tailnet: immich server,
pgvector postgres, valkey cache, machine-learning worker, Dex OIDC client,
Flux Kustomizations.

Design: apps/immich*
Related: dex OIDC
Signed-off-by: Shikanime Deva <william.phetsinorath@shikanime.studio>
Change-Id: Ic8a0c61d9d5ad0db4c0024d0bd3693646a6a6964